### PR TITLE
Synchronize quickstart with deployment-recipes repository

### DIFF
--- a/content/guides/getting_started.md
+++ b/content/guides/getting_started.md
@@ -61,14 +61,6 @@ curl --cacert cacert.pem -H "Authorization: Bearer $ACCESS_TOKEN" https://foobar
 # This should respond with an empty set of Components: {"Components":[]}
 ```
 
-Create a separate token that a script can use to update dnsmasq
-
-```bash {title="Generate a dedicated token and use it with dnsmasq"}
- echo "DNSMASQ_ACCESS_TOKEN=$(gen_access_token)" >> .env
- docker compose -f base.yml -f postgres.yml -f jwt-security.yml -f haproxy-api-gateway.yml -f openchami-svcs.yml -f autocert.yml -f dnsmasq.yml up -d
-
-```
-
 Explore the environment on [Github](https://github.com/openchami/deployment-recipes/tree/main/quickstart/).
 {{< /callout >}}
 

--- a/content/guides/getting_started.md
+++ b/content/guides/getting_started.md
@@ -62,6 +62,8 @@ curl --cacert cacert.pem -H "Authorization: Bearer $ACCESS_TOKEN" https://foobar
 ```
 
 Explore the environment on [Github](https://github.com/openchami/deployment-recipes/tree/main/quickstart/).
+
+Also, take a look at the [`ochami` command line tool](https://github.com/OpenCHAMI/ochami) for interacting with OpenCHAMI beyond using cURL.
 {{< /callout >}}
 
 ### Dependencies and Assumptions

--- a/content/guides/getting_started.md
+++ b/content/guides/getting_started.md
@@ -38,8 +38,8 @@ git clone https://github.com/OpenCHAMI/deployment-recipes.git
 # Enter the quickstart directory
 cd deployment-recipes/quickstart/
 # Create the secrets in the .env file.  Do not share them with anyone. 
-# This also sets the system name for your certificates.  In our case, we'll call our system "foobar".  The full url will be https://foobar.openchami.cluster which you can set in /etc/hosts to make life easier for you later
-./generate-configs.sh foobar
+# This also sets the system name for your certificates.  The system will be called "foobar" and the full url will be https://foobar.openchami.cluster which can be set in /etc/hosts to make life easier for you later
+./generate-configs.sh
 # Start the services
 docker compose -f base.yml -f postgres.yml -f jwt-security.yml -f haproxy-api-gateway.yml -f  openchami-svcs.yml -f autocert.yml up -d
 # This shouldn't take too long.  A minute or two depending on how long pulling containers takes.

--- a/content/guides/getting_started.md
+++ b/content/guides/getting_started.md
@@ -69,7 +69,7 @@ Create a separate token that a script can use to update dnsmasq
 
 ```
 
-Explore the environment on [Github](https://github.com/openchami/deployment-recipes/tree/main/lanl/).
+Explore the environment on [Github](https://github.com/openchami/deployment-recipes/tree/main/quickstart/).
 {{< /callout >}}
 
 ### Dependencies and Assumptions


### PR DESCRIPTION
A few things need updating/correction:
- GitHub link to quickstart directory in [deployment-recipes](https://github.com/OpenCHAMI/deployment-recipes)
- Invocation of `generate-configs.sh`
- Removal of old dnsmasq token generation (dnsmasq was replaced with CoreDHCP + [coresmd](https://github.com/OpenCHAMI/coresmd))

Also, mention of the [`ochami` CLI](https://github.com/OpenCHAMI/ochami) is added, since it is anticipated that users would probably like something less verbose than cURL for interaction with the services.