### PR TITLE
Add blog post about the Magellan `secrets` feature

### DIFF
--- a/content/blog/bridging-idp-1/index.md
+++ b/content/blog/bridging-idp-1/index.md
@@ -1,10 +1,10 @@
 ---
-title = 'Bridging the Gap between External Identity Provider and Self-Hosted Authorization Server (Part 1)'
-date = 2024-06-03T03:43:00-05:00
-draft = false
-weight = 12
-categories = ['LANL', 'Development']
-contributors = ["David J. Allen (LANL)"]
+title: 'Bridging the Gap between External Identity Provider and Self-Hosted Authorization Server (Part 1)'
+date:  2024-06-03T03:43:00-05:00
+draft:  false
+weight:  12
+categories:  ['LANL', 'Development']
+contributors: ["David J. Allen (LANL)"]
 ---
 
 

--- a/content/blog/bridging-idp-1/index.md
+++ b/content/blog/bridging-idp-1/index.md
@@ -1,14 +1,14 @@
-+++
+---
 title = 'Bridging the Gap between External Identity Provider and Self-Hosted Authorization Server (Part 1)'
 date = 2024-06-03T03:43:00-05:00
 draft = false
 weight = 12
 categories = ['LANL', 'Development']
 contributors = ["David J. Allen (LANL)"]
-+++
+---
 
 
-When it comes to authentication, it is not unrealistic to want to use an existing identity provider, like Gitlab or Google, to provide users with multiple login options. This prevents burdening the user to register another account with your service and lowers the barrier for them to use your service. Instead, the user is able to use an account they are more likely to already have with other sites. This is also good for developers as it allows them to skip having to create their own login page and maintain their own backend with a lot of the wiring need to grant users access to resources, given that the developers trust the identity provider. The application or service presenting the login challenge must first register their application with the trusted identity provider so that the IDP can verify the application credentials, ask the user to consent to allowing certain information or actions, and send an ID token and/or access token to the appropriate callback URI  for the service provider to consume. 
+When it comes to authentication, it is not unrealistic to want to use an existing identity provider, like Gitlab or Google, to provide users with multiple login options. This prevents burdening the user to register another account with your service and lowers the barrier for them to use your service. Instead, the user is able to use an account they are more likely to already have with other sites. This is also good for developers as it allows them to skip having to create their own login page and maintain their own backend with a lot of the wiring need to grant users access to resources, given that the developers trust the identity provider. The application or service presenting the login challenge must first register their application with the trusted identity provider so that the IDP can verify the application credentials, ask the user to consent to allowing certain information or actions, and send an ID token and/or access token to the appropriate callback URI  for the service provider to consume.
 
 ## So what's the Problem?
 
@@ -22,16 +22,16 @@ So when we want to get an access token for our service, we would have to go thro
 
 3. If the user agrees to consent, then the IDP sends an authorization code to the service as defined by [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1) with an authorization code.
 
-4. Finally, the service must make a request back to the IDP presenting the code in the HTTP headers to perform the token grant and receive a bearer token. 
-   
+4. Finally, the service must make a request back to the IDP presenting the code in the HTTP headers to perform the token grant and receive a bearer token.
+
    Here's an example of what an ID token would look like coming from an OIDC implementation as an encoded string:
-   
+
    ```json
    eyJhbGciOiJSUzI1NiIsImtpZCI6IjBiYTdjYjhlLWRhZDItNGY5ZS05NmU0LWIzNzMyYjcxYWU3NyIsInR5cCI6IkpXVCJ9.eyJhdWQiOltdLCJjbGllbnRfaWQiOiI3MzhhYzYwMS04ZmQ0LTQ3OTctOTIyZC1lZWI0YzU5MjcwNjciLCJleHAiOjE3MTc0NDg5MzQsImV4dCI6e30sImlhdCI6MTcxNzQ0NTMzNCwiaXNzIjoiaHR0cHM6Ly90ZS1oZWFkLm9wZW5jaGFtaS5jbHVzdGVyLyIsImp0aSI6ImUzMTg2Njc1LTQzN2QtNGFjNi04NzQ1LWQ4NGU1MGJiNDkxZiIsIm5iZiI6MTcxNzQ0NTMzNCwic2NwIjpbIm9wZW5pZCIsInNtZC5yZWFkIl0sInN1YiI6IjczOGFjNjAxLThmZDQtNDc5Ny05MjJkLWVlYjRjNTkyNzA2NyJ9.YdPW9frHjFUBOwKdIO9ax84KB33WCSKSCLC9IlBsvWOyXo38EWzyICn31sRR_xACr2YETe90b5LpulXLON05S-NRvkPmBRDUeHdmLtLSHOivFuzvmqF9C0UmCVNkWdQqR4rUcuytSGpgwadXdLDzdy-vSj6gB5kpUT6h9WwavdAbAipvNnR81l_Kpuf7OAmJG3yF1lDkLYXBEm1-6xcbzBCKuK--8sojMlkykT3UolafCVy1jCWLTwVpGCG39O2aJkYuXb5XsdVziY9j-1v_9N60QQA13ntRuCCSGSlGqGEhldzkHHJ4sCAVR-HoQyMKMEMetFh1rt_h8U3FNprTW1Q1sai3N1GD5g345zO2kDezCGhBHbIiDkVpsUXHH39T4wkDoOe5v9Kvl6Gq8R5xhw3oq2yrb9OgFeZm0EqEwP3UZp2wnOuXA75qQzKg2Q9uI6Y7Bf0w_coPGrwWnzfuE9_Cvcu5mwbgRDnMvEN_JpotDbPLbm1YIUYgWBuBipf512HJFz_sn3iMiXLDJGHQ-qRYIzX7oZp4OzKBvxJe2UtXs9alneULa20un75bbJMbGqhw9PgJo6sjQiGGt4t9NZBw8lYPwG5KWp4eeEB_olr6zsvnIAZPuEsNI7xVVJqNaniqrdz9VY0TlLoRH2_Hj0c7vH3grXHCa4vxYGYi08E
    ```
-   
+
    And this is what it would look like decoded into JSON objects excluding the signature. (Note: This is actually an access token, but an ID token would look similar.)
-   
+
    ```json
     // header
     {
@@ -71,7 +71,7 @@ graph TD
     end
 ```
 
-If your authorization server is OIDC compliant, then this is bad news since the server will be required to reject the ID token. One solution would be to provided a way of specifying the audience when registering a client or with the authorization code URL as just mentioned. Most sites probably won't allow this out-of-the-box or have their own custom, non-standard way of doing this which is certainly not ideal. [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707#name-authorization-request) mentions resource indicators which may have remedy the situation, but as for now, this does not seem the way to go. 
+If your authorization server is OIDC compliant, then this is bad news since the server will be required to reject the ID token. One solution would be to provided a way of specifying the audience when registering a client or with the authorization code URL as just mentioned. Most sites probably won't allow this out-of-the-box or have their own custom, non-standard way of doing this which is certainly not ideal. [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707#name-authorization-request) mentions resource indicators which may have remedy the situation, but as for now, this does not seem the way to go.
 
 A better solution would be for your application or service to consume the ID token itself and then handle the an access token grant separately. This is the route that OpenCHAMI is taking for now, and it seems to work fine for our purposes, but it certainly has its advantages and disadvantages. Let's take a closer look at this solution to understand why we might and might not want to go forward with it.
 

--- a/content/blog/bridging-idp-2/index.md
+++ b/content/blog/bridging-idp-2/index.md
@@ -1,10 +1,10 @@
 ---
-title = 'Bridging the Gap between External Identity Provider and Self-Hosted Authorization Server (Part 2)'
-date = 2024-12-01T03:43:00-05:00
-draft = true
-weight = 13
-categories = ['LANL', 'Development']
-contributors = ["David J. Allen (LANL)"]
+title: 'Bridging the Gap between External Identity Provider and Self-Hosted Authorization Server (Part 2)'
+date: 2024-12-01T03:43:00-05:00
+draft: true
+weight: 13
+categories: ['LANL', 'Development']
+contributors: ["David J. Allen (LANL)"]
 ---
 
 # Bridging the Gap between Identity Provider and Authorization Server (Part 2)

--- a/content/blog/bridging-idp-2/index.md
+++ b/content/blog/bridging-idp-2/index.md
@@ -1,11 +1,11 @@
-+++
+---
 title = 'Bridging the Gap between External Identity Provider and Self-Hosted Authorization Server (Part 2)'
 date = 2024-12-01T03:43:00-05:00
 draft = true
 weight = 13
 categories = ['LANL', 'Development']
 contributors = ["David J. Allen (LANL)"]
-+++
+---
 
 # Bridging the Gap between Identity Provider and Authorization Server (Part 2)
 
@@ -13,7 +13,7 @@ This post is going to cover in more detail about addressing the issues mentioned
 
 ## So what is OPAAL exactly?
 
-The acronym stands for "OIDC Provider Automated Authorization Login" and is a tool designed specifically to streamline consuming ID tokens from an external identity provider (IDP) from the OpenCHAMI stack. OPAAL would use the claims from the ID token to create another JWT to use with our internal OIDC authorization server to grant access to internal resources via an access token. This didn't seem like an unreasonable thing to do at the time, but we ran into some problems before coming to this solution. 
+The acronym stands for "OIDC Provider Automated Authorization Login" and is a tool designed specifically to streamline consuming ID tokens from an external identity provider (IDP) from the OpenCHAMI stack. OPAAL would use the claims from the ID token to create another JWT to use with our internal OIDC authorization server to grant access to internal resources via an access token. This didn't seem like an unreasonable thing to do at the time, but we ran into some problems before coming to this solution.
 
 Our use case required logging into a self-hosted instance of GitLab that we did not control and routing the response to back somewhere we could consume the ID token. This was really beneficial because it did not require us to set up our own IDP service. Initially, this was done with Ory Hydra, but we ran into complications trying to set up the login flow with Kratos's self-service nodes for Identity and Session management within the Ory stack. Documentation was limited and support was almost non-existent, so we moved on. And so, here we are.
 
@@ -44,7 +44,7 @@ c -- redirect with token --> d[OPAAL]
 d --> e["authorization server (Hydra)"]
 ```
 
-After consuming the ID token, OPAAL creates and signs another JWT, but not to return to the user as an access token however. Since OPAAL is not an OIDC-compliant provider, having *it issue access tokens would be a bad idea*. Instead, the JWT that OPAAL creates is to perform a JWT bearer grant with Hydra. The details about how this work is explained in [Hydra's documentation](https://www.ory.sh/docs/hydra/guides/jwt). Ultimately, using the JWT bearer grant allowed for flexible access token customization that was needed to include information from the ID token, which would not have been possible using the other grant types. 
+After consuming the ID token, OPAAL creates and signs another JWT, but not to return to the user as an access token however. Since OPAAL is not an OIDC-compliant provider, having *it issue access tokens would be a bad idea*. Instead, the JWT that OPAAL creates is to perform a JWT bearer grant with Hydra. The details about how this work is explained in [Hydra's documentation](https://www.ory.sh/docs/hydra/guides/jwt). Ultimately, using the JWT bearer grant allowed for flexible access token customization that was needed to include information from the ID token, which would not have been possible using the other grant types.
 
 ### Why does the tool exists?
 

--- a/content/blog/magellan-secrets/index.md
+++ b/content/blog/magellan-secrets/index.md
@@ -12,9 +12,9 @@ contributors: ["David J. Allen"]
 
 # Storing BMC Credentials with Magellan
 
-Baseboard Management Controllers (BMCs) are essential for remote hardware management but managing their credentials can pose security risks if not done carefully. With the [v0.20](https://github.com/OpenCHAMI/magellan/releases/tag/v0.2.0) release of Magellan, administrators now have a straightforward and secure solution: the `secrets` command, designed to store encrypted BMC credentials locally, reducing complexity and enhancing safety. This post outlines this new capability, demonstrates typical workflows, and addresses some important implementation and security considerations.
+Baseboard Management Controllers (BMCs) are essential for remote hardware management but managing their credentials can pose security risks if not done carefully. With the [v0.2.0](https://github.com/OpenCHAMI/magellan/releases/tag/v0.2.0) release of Magellan, administrators now have a straightforward and secure solution: the `secrets` command, designed to store encrypted BMC credentials locally, reducing complexity and enhancing safety. This post outlines this new capability, demonstrates typical workflows, and addresses some important implementation and security considerations.
 
-As of the [v0.20](https://github.com/OpenCHAMI/magellan/releases/tag/v0.2.0) release, it's now possible to store BMC credentials in an encrypted local secret store using the new `secrets` command. This is incredibly useful when you're trying to access multiple BMC nodes that might have different usernames and passwords without having to specify each one every single time. 
+As of the [v0.2.0](https://github.com/OpenCHAMI/magellan/releases/tag/v0.2.0) release, it's now possible to store BMC credentials in an encrypted local secret store using the new `secrets` command. This is incredibly useful when you're trying to access multiple BMC nodes that might have different usernames and passwords without having to specify each one every single time.
 
 This post will provide a quick rundown about this new feature, how to use it, and some of the security considerations taken into account with its implementation.
 
@@ -40,32 +40,32 @@ The typical `magellan` workflow might look something like this:
 With SecretStore, the classic workflow is still possible.  The StaticStore implementation responds with the same username and password for all nodes.  It gets more interesting with the LocalStore which allows the admin to securely store a different username and password for each node and use them for the scan.
 
 #### 1. Perform a `scan` to find BMC nodes on network
-   
+
    ```bash
    magellan scan --subnet 172.16.0.0 --subnet-mask 255.255.255.0
    ```
 
 #### 2. Generate and set the `MASTER_KEY` environment variable using the new `secrets generatekey` command
-   
+
    ```bash
    # Using the same MASTER_KEY in the future is essential.  Keep this safe.
    export MASTER_KEY=$(magellan secrets generatekey)
    ```
 
 #### 3. Inspect the BMC nodes found from the `scan` using the `list` command
-   
+
    ```bash
    magellan list
    ```
 
 #### 4. Store secrets for the BMC nodes listed by the `list` command using `secrets store` command (host must be EXACT!)
-   
+
    ```bash
    magellan secrets store https://172.16.0.101:443 $bmc_username:$bmc_password
    ```
 
 #### 5. Run a `collect` or `crawl` to gather inventory information providing the login credentials for the BMC nodes
-   
+
    ```bash
    magellan crawl https://172.16.0.101:443 -i
    magellan collect \
@@ -79,7 +79,7 @@ Some of the new `secrets` sub-commands are omitted here for brevity, but can be 
 
 ## Are my secrets *actually* safe?
 
-The implementation is simple and straight-forward, but it is sufficient for `magellan`. There were a couple of concerns that we wanted to address. 
+The implementation is simple and straight-forward, but it is sufficient for `magellan`. There were a couple of concerns that we wanted to address.
 
 We obviously did not want to store anything in plain-text, which is *super bad*. The consensus was that the secrets needed to be stored in a way that was undecipherable by anyone without the appropriate key. Right now, this is only done with `magellan secrets retrieve` for a single `secretID` provided.
 
@@ -90,7 +90,7 @@ The file itself can always be protected using permissions and such so there wasn
 
 ## What's Next?
 
-With Magellan v0.20, securely managing BMC credentials has become easier and more streamlined. The introduction of the new `secrets` command provides a secure way to store and retrieve encrypted credentials locally, significantly enhancing both usability and security for diverse infrastructures.
+With Magellan v0.2.0, securely managing BMC credentials has become easier and more streamlined. The introduction of the new `secrets` command provides a secure way to store and retrieve encrypted credentials locally, significantly enhancing both usability and security for diverse infrastructures.
 
 Future enhancements may explore additional security layers and support integration with external secret management tools, especially if Magellan evolves into a micro-service architecture.
 

--- a/content/blog/magellan-secrets/index.md
+++ b/content/blog/magellan-secrets/index.md
@@ -1,0 +1,92 @@
+---
+title: "Storing BMC Credentails with Magellan"
+description: "A new feature added to OpenCHAMI Magellan that makes BMC login easier, efficient, and secure."
+date: 2025-03-24T00:00:00+00:00
+lastmod: 2025-03-24T00:00:00+00:00
+draft: false
+weight: 10
+categories: ["Security", "HPC", "Magellan"]
+tags: ["Magellan", "BMC Discovery", "Inventory", "Secrets"]
+contributors: ["David J. Allen"]
+---
+
+# Storing BMC Credentials with Magellan
+
+As of the [v0.20](https://github.com/OpenCHAMI/magellan/releases/tag/v0.2.0) release, it's now possible to store BMC credentials in an encrypted local secret store using the new `secrets` command. This is incredibly useful when you're trying to access multiple BMC nodes that might have different usernames and passwords without having to specify each one every single time. Nothing is stored in plain-text other than the `secretID` key in a file, but retrieving secret values *always* require the exact same key used to store the secret. 
+
+This post will provide a quick rundown about this new feature, how to use it, and some of the considerations taken into account with its implementation.
+
+## How does it work?
+
+The secret store is built from a `SecretStore` interface with two separate implementations: a `StaticStore` and a `LocalSecretStore`. 
+
+The `StaticStore` maintains the original behavior of `magellan` prior to the new feature being added via the `--username/--password` flags. The `LocalSecretStore` encrypts the password using the `MASTER_KEY` and stores it to a file. Both are now being used implicitly whenever a `collect` or a `crawl` is executed.
+
+Furthermore, the `SecretStore` interface allows us to create new (and possibly better) implementations in the future if needed.
+
+### Typical Workflow using the Secret Store
+
+The typical `magellan` workflow might look something like this:
+
+1. Perform a `scan` to find BMC nodes on network
+
+2. Run a `collect` or `crawl` to gather inventory information providing the login credentials for the BMC nodes
+
+However, as stated above, the BMC nodes may have different login credentials. Therefore, the workflow with the secrets store would have a few extra steps:
+
+1. Perform a `scan` to find BMC nodes on network
+   
+   ```bash
+   magellan scan --subnet 172.16.0.0 --subnet-mask 255.255.255.0
+   ```
+
+2. Generate and set the `MASTER_KEY` environment variable using the new `secrets generatekey` command
+   
+   ```bash
+   export MASTER_KEY=$(magellan secrets generatekey)
+   ```
+
+3. Inspect the BMC nodes found from the `scan` using the `list` command
+   
+   ```bash
+   magellan list
+   ```
+
+4. Store secrets for the BMC nodes listed by the `list` command using `secrets store` command (host must be EXACT!)
+   
+   ```bash
+   magellan secrets store https://172.16.0.101:443 $bmc_username:$bmc_password
+   ```
+
+5. Run a `collect` or `crawl` to gather inventory information providing the login credentials for the BMC nodes
+   
+   ```bash
+   magellan crawl https://172.16.0.101:443 -i
+   magellan collect \
+     --username $default_bmc_username \
+     --password $default_bmc_password \
+     --host https://smd.openchami.cluster \
+     --cacert ochami.pem
+   ```
+
+Some of the new `secrets` sub-commands are omitted here for brevity, but can be viewed with `magellan secrets --help`. Note that in step 5, both the `--username` and `--password` flags are still being used like before. If no credential is found for a specific BMC node in the local store, then the provided values for both flags above will be used as a fallback. This allows us to have to original behavior before if all of the BMC nodes have the same login credentials, while also being able to only specify the ones that are different.
+
+## Are my secrets *actually* safe?
+
+The implementation is simple and straight-forward, but it is sufficient for `magellan`. There were a couple of concerns that we wanted to address. 
+
+We obviously did not want to store anything in plain-text, which is *super bad*. The consensus was that the secrets needed to be stored in a way that was undecipherable by anyone without the appropriate key. Right now, this is only done with `magellan secrets retrieve` for a single `secretID` provided.
+
+We also wanted to make sure that we could not access the same store with a different `MASTER_KEY`. Trying to do so will return a cryptographic-related error message:
+
+```bash
+Error retrieving secret: cipher: message authentication failed
+```
+
+The file itself can always be protected using permissions and such so there wasn't anything to do there. And since there's no server/daemon running, there's no need to worry too much about extracting secrets remotely...*for now*.
+
+## What's Next?
+
+The current implementation of the secret store works and is needed for some other experimental features for another project (maybe another blog post soonish). In the future, however, we may want to investigate measures to prevent exfiltration of secrets if we decide to turn `magellan` into a micro-service.
+
+

--- a/content/blog/magellan-secrets/index.md
+++ b/content/blog/magellan-secrets/index.md
@@ -12,53 +12,59 @@ contributors: ["David J. Allen"]
 
 # Storing BMC Credentials with Magellan
 
-As of the [v0.20](https://github.com/OpenCHAMI/magellan/releases/tag/v0.2.0) release, it's now possible to store BMC credentials in an encrypted local secret store using the new `secrets` command. This is incredibly useful when you're trying to access multiple BMC nodes that might have different usernames and passwords without having to specify each one every single time. Nothing is stored in plain-text other than the `secretID` key in a file, but retrieving secret values *always* require the exact same key used to store the secret. 
+Baseboard Management Controllers (BMCs) are essential for remote hardware management but managing their credentials can pose security risks if not done carefully. With the [v0.20](https://github.com/OpenCHAMI/magellan/releases/tag/v0.2.0) release of Magellan, administrators now have a straightforward and secure solution: the `secrets` command, designed to store encrypted BMC credentials locally, reducing complexity and enhancing safety. This post outlines this new capability, demonstrates typical workflows, and addresses some important implementation and security considerations.
 
-This post will provide a quick rundown about this new feature, how to use it, and some of the considerations taken into account with its implementation.
+As of the [v0.20](https://github.com/OpenCHAMI/magellan/releases/tag/v0.2.0) release, it's now possible to store BMC credentials in an encrypted local secret store using the new `secrets` command. This is incredibly useful when you're trying to access multiple BMC nodes that might have different usernames and passwords without having to specify each one every single time. 
+
+This post will provide a quick rundown about this new feature, how to use it, and some of the security considerations taken into account with its implementation.
 
 ## How does it work?
 
-The secret store is built from a `SecretStore` interface with two separate implementations: a `StaticStore` and a `LocalSecretStore`. 
+The secret store is built from a `SecretStore` [interface](https://github.com/OpenCHAMI/magellan/blob/48a53f6d5d5cb6ac6988a17511052678985f8a07/pkg/secrets/main.go#L1-L7) with two separate implementations: a `StaticStore` and a `LocalSecretStore`.  Future implementations could leverage hashicorp vault or other more mature secret stores.
 
 The `StaticStore` maintains the original behavior of `magellan` prior to the new feature being added via the `--username/--password` flags. The `LocalSecretStore` encrypts the password using the `MASTER_KEY` and stores it to a file. Both are now being used implicitly whenever a `collect` or a `crawl` is executed.
 
 Furthermore, the `SecretStore` interface allows us to create new (and possibly better) implementations in the future if needed.
 
-### Typical Workflow using the Secret Store
+### Classic Workflow for Magellan
 
 The typical `magellan` workflow might look something like this:
 
 1. Perform a `scan` to find BMC nodes on network
 
-2. Run a `collect` or `crawl` to gather inventory information providing the login credentials for the BMC nodes
+2. Run `collect` or `crawl` using a common username/password to gather inventory information providing the login credentials for the BMC nodes
 
-However, as stated above, the BMC nodes may have different login credentials. Therefore, the workflow with the secrets store would have a few extra steps:
 
-1. Perform a `scan` to find BMC nodes on network
+### Magellan Workflow with SecretStore
+
+With SecretStore, the classic workflow is still possible.  The StaticStore implementation responds with the same username and password for all nodes.  It gets more interesting with the LocalStore which allows the admin to securely store a different username and password for each node and use them for the scan.
+
+#### 1. Perform a `scan` to find BMC nodes on network
    
    ```bash
    magellan scan --subnet 172.16.0.0 --subnet-mask 255.255.255.0
    ```
 
-2. Generate and set the `MASTER_KEY` environment variable using the new `secrets generatekey` command
+#### 2. Generate and set the `MASTER_KEY` environment variable using the new `secrets generatekey` command
    
    ```bash
+   # Using the same MASTER_KEY in the future is essential.  Keep this safe.
    export MASTER_KEY=$(magellan secrets generatekey)
    ```
 
-3. Inspect the BMC nodes found from the `scan` using the `list` command
+#### 3. Inspect the BMC nodes found from the `scan` using the `list` command
    
    ```bash
    magellan list
    ```
 
-4. Store secrets for the BMC nodes listed by the `list` command using `secrets store` command (host must be EXACT!)
+#### 4. Store secrets for the BMC nodes listed by the `list` command using `secrets store` command (host must be EXACT!)
    
    ```bash
    magellan secrets store https://172.16.0.101:443 $bmc_username:$bmc_password
    ```
 
-5. Run a `collect` or `crawl` to gather inventory information providing the login credentials for the BMC nodes
+#### 5. Run a `collect` or `crawl` to gather inventory information providing the login credentials for the BMC nodes
    
    ```bash
    magellan crawl https://172.16.0.101:443 -i
@@ -77,16 +83,15 @@ The implementation is simple and straight-forward, but it is sufficient for `mag
 
 We obviously did not want to store anything in plain-text, which is *super bad*. The consensus was that the secrets needed to be stored in a way that was undecipherable by anyone without the appropriate key. Right now, this is only done with `magellan secrets retrieve` for a single `secretID` provided.
 
-We also wanted to make sure that we could not access the same store with a different `MASTER_KEY`. Trying to do so will return a cryptographic-related error message:
-
-```bash
-Error retrieving secret: cipher: message authentication failed
-```
+The `LocalStore` implementation relies on AES-GCM encryption of each secret using a separate key.  Rather than manually manage a different key for each secret, the keys are generated dynamically and predictably using a procedure called [HKDF](https://en.wikipedia.org/wiki/HKDF) which leverages a 32-bit `MASTER_KEY`.  Without the id of the secret -and- the appropriate id of the secret, the storage file is useless.
 
 The file itself can always be protected using permissions and such so there wasn't anything to do there. And since there's no server/daemon running, there's no need to worry too much about extracting secrets remotely...*for now*.
 
+
 ## What's Next?
 
-The current implementation of the secret store works and is needed for some other experimental features for another project (maybe another blog post soonish). In the future, however, we may want to investigate measures to prevent exfiltration of secrets if we decide to turn `magellan` into a micro-service.
+With Magellan v0.20, securely managing BMC credentials has become easier and more streamlined. The introduction of the new `secrets` command provides a secure way to store and retrieve encrypted credentials locally, significantly enhancing both usability and security for diverse infrastructures.
 
+Future enhancements may explore additional security layers and support integration with external secret management tools, especially if Magellan evolves into a micro-service architecture.
 
+Your feedback is valuable! If you'd like to contribute ideas, report issues, or request new features, we invite you to [open an issue on GitHub](https://github.com/OpenCHAMI/magellan/issues) or directly submit a pull request.


### PR DESCRIPTION
This PR adds a new blog post explaining the new `secrets` feature and how it works. It also corrects the frontmatter block replacing the `+++` opening/closing tags.