### PR TITLE
Add configurator to docker compose quickstart command

### DIFF
--- a/content/guides/getting_started.md
+++ b/content/guides/getting_started.md
@@ -41,7 +41,7 @@ cd deployment-recipes/quickstart/
 # This also sets the system name for your certificates.  The system will be called "foobar" and the full url will be https://foobar.openchami.cluster which can be set in /etc/hosts to make life easier for you later
 ./generate-configs.sh
 # Start the services
-docker compose -f base.yml -f postgres.yml -f jwt-security.yml -f haproxy-api-gateway.yml -f  openchami-svcs.yml -f autocert.yml up -d
+docker compose -f base.yml -f postgres.yml -f jwt-security.yml -f haproxy-api-gateway.yml -f  openchami-svcs.yml -f autocert.yml -f configurator.yml up -d
 # This shouldn't take too long.  A minute or two depending on how long pulling containers takes.
 ```
 


### PR DESCRIPTION
When running the docker compose in the quickstart instructions,
the haproxy-api-gateway was failing due to not having
configurator setup. Adding the `configurator.yml` to the docker
compose command fixed this issue.