### PR TITLE
Fix: update events page with TACC summit

### DIFF
--- a/content/events/Conferences/2025/CUG25.md
+++ b/content/events/Conferences/2025/CUG25.md
@@ -12,7 +12,7 @@ contributors = ["Travis Cotton"]
 
 **Date**: May 4–8, 2025
 
-**Location**: Stony Brook University, New York, NY
+**Location**: The Westin Jersey City Newport, 479 Washington Boulevard Jersey City, NJ 07310
 
 **Website**: [CUG 2025 Registration](https://cug.org/cug-2025-registration/)
 

--- a/content/events/Conferences/2025/hpc-security-workshop-nist.md
+++ b/content/events/Conferences/2025/hpc-security-workshop-nist.md
@@ -1,6 +1,6 @@
 +++
 title = '5th High-Performance Computing Security Workshop (NIST)'
-date = 2025-04-07
+date = 2025-05-06
 start_date = 2025-05-07
 end_date = 2025-05-08
 draft = false
@@ -12,7 +12,7 @@ contributors = ["Alex Lovell-Troy"]
 
 **Date**: May 7–8, 2025
 
-**Location**: NIST NCCoE, Rockville, MD
+**Location**: NIST NCCoE,9700 Great Seneca Highway, Rockville, MD
 
 **Website**: [NIST HPC Security Workshop](https://www.nist.gov/news-events/events/2025/05/5th-high-performance-computing-security-workshop)
 

--- a/content/events/Conferences/2025/hpsf-conference.md
+++ b/content/events/Conferences/2025/hpsf-conference.md
@@ -14,5 +14,6 @@ contributors = ["Matt Williams"]
 **Location**: Chicago, IL
 
 **Website**: [HPSF Conference](https://events.linuxfoundation.org/hpsf-conference/)
+**Registration**:[HPSF Registration](https://events.linuxfoundation.org/hpsf-conference/register/)
 
 OpenCHAMI will be attending, with **Matt Williams** representing OpenCHAMI.

--- a/content/events/Conferences/2025/isc-high-performance-2025.md
+++ b/content/events/Conferences/2025/isc-high-performance-2025.md
@@ -12,10 +12,12 @@ contributors = ["Alex", "David", "Devon"]
 
 **Date**: June 10–13, 2025
 
-**Location**: Congress Center Hamburg, Hamburg, Germany
+**Location**: CCH-Congress Center Hamburg, Congressplatz 1, 20355 Hamburg, Germany
 
 **Website**: [ISC 2025 Attendance](https://isc-hpc.com/attendance/)
 
-One of the premier HPC conferences. **Alex, David, and Devon** will present tutorials, a workshop, and represent OpenCHAMI at the DOE booth.
+**Regisration**: [ISC 2025 Registration](https://isc-hpc.com/registration/)
+
+One of the premier HPC conferences. **Alex, David, and Devon** will present [tutorials](https://isc.app.swapcard.com/widget/event/isc-high-performance-2025/planning/UGxhbm5pbmdfMjU4MTgxMA==), a workshop, and represent OpenCHAMI at the DOE booth.
 
 Read more about OpenCHAMI, [here](/docs/introduction-to-openchami/) and try it yourself through the [install guide](/guides/getting_started/).

--- a/content/events/Summits/2025/TACC25.md
+++ b/content/events/Summits/2025/TACC25.md
@@ -1,0 +1,62 @@
++++
+title = 'OpenCHAMI Developer Summit @ TACC 2025'
+date = 2025-05-06        # page publication date
+start_date = 2025-09-09
+end_date = 2025-09-11
+draft = false
+categories = ['Summit', 'Development', 'HPC']
+contributors = ["OpenCHAMI Core Team"]
++++
+
+
+### Texas Advanced Computing Center • Austin, TX • September 9 – 11 2025
+**Event**: OpenCHAMI Developer Summit @ TACC 2025
+
+**Date**: September 9–11, 2025
+
+**Location**: Texas Advanced Computing Center, Austin, TX
+
+**Website**: TBD
+
+**Hosts**:  TACC, OpenCHAMI Community
+
+
+We’re thrilled to invite the entire OpenCHAMI community to three days of collaboration at the **Texas Advanced Computing Center (TACC)**. Whether you’re new to OpenCHAMI or a long-time contributor, there will be tracks for every skill level.
+
+---
+
+## Who Should Attend?
+
+- **Sysadmins** deploying or evaluating OpenCHAMI in production
+- **Developers** who want to contribute code, docs, or integrations
+- **HPC practitioners & researchers** curious about automated system management
+- Anyone interested in **community-driven, vendor-neutral** HPC tooling
+
+---
+
+## Agenda&nbsp;Snapshot
+
+| Day | Theme | Highlights |
+|---|---|---|
+| **Day 1 – Introductions & Current State** | *Setting the Stage* | Project history • Site reports • Needs & gaps workshop • Status review |
+| **Day 2 – Tutorials & Governance** | *Hands-On & Cleanup* | Full-day deployment tutorial • Parallel TSC/governance refinement track |
+| **Day 3 – Hackathon & Road-Mapping** | *Building the Future* | Code, scripting, docs sprint • RFD drafting • Summit wrap-up & next steps |
+
+---
+
+## Why Attend?
+
+- **Network** with OpenCHAMI contributors, site admins, and developers
+- **Learn** best practices for large-scale HPC automation and orchestration
+- **Shape** the project’s future via live RFD and governance sessions
+- **Hack** on real code and docs to advance the OpenCHAMI roadmap
+
+---
+
+> **We look forward to seeing you at TACC!**
+> A formal invitation with hotel and travel details will follow shortly.
+> For questions or attendee suggestions, email **[contact@openchami.org](contact@openchami.org)**.
+
+---
+
+*Save the date and stay tuned for more updates!*


### PR DESCRIPTION
Fixed event details and added TACC 25 