### PR TITLE
Add blogpost for PCS workflow on BMCs and PDUs

### DIFF
--- a/content/blog/power-control/index.md
+++ b/content/blog/power-control/index.md
@@ -98,13 +98,6 @@ PCS receives this command, performs the action on the device, and its next polli
 
 ---
 
-## Why This Approach Matters 💡
-
-* **Stateful Awareness**: Because PCS is constantly polling, it has a near-real-time view of your hardware's power state. It can even detect manual changes made outside of PCS, providing a truly reliable source of truth.
-* **Performance and Responsiveness**: User queries are fast because they hit the PCS cache, not the slow hardware interfaces.
-* **True Abstraction**: A sysadmin no longer needs to worry if they're talking to a `Redfish` or `JAWS` device—they just talk to the unified PCS API.
-* **Secure by Design**: Integrating with Vault for credential management removes the need to pass plaintext passwords in scripts or command-line histories.
-
 ## What’s Next?
 
 With these enhancements, OpenCHAMI has taken a major step forward in unified, programmatic hardware management. The stateful, polling model we've established could easily be extended to manage other critical data center hardware, such as network switches or smart cooling units, under the same consistent API.


### PR DESCRIPTION
This blog post captures the recent work that has gone into PCS, Magellan, and SMD to make power control of real hardware possible in Magellan using tools exclusively part of the OpenCHAMI stack (i.e., Magellan instead of SMD inventory, PCS with a new JAWS interface, etc.).

The demo that this was based on is on GitHub here: https://github.com/bmcdonald3/openchami-demo. There is more information and more content in that repo, including the full deployment recipe that was used for this demo.