### PR TITLE
Inventory blog

### DIFF
--- a/content/blog/fabrica-inventory/index.md
+++ b/content/blog/fabrica-inventory/index.md
@@ -66,7 +66,7 @@ This creates `pkg/resources/device/device.go`. We open it and edit the two gener
 
 We want this struct to be empty. The system, not the user, populates the device data.
 
-```bash
+```go
 // DeviceSpec defines the desired state of a Device
 // This should be empty for our inventory-API, as all data
 // is observed state populated by the system.


### PR DESCRIPTION
### Description

Adding a blog post for using Fabrica to take the data model from https://github.com/OpenCHAMI/roadmap/issues/112 and turn it into an actual service. Also includes a section for extending beyond simple CRUD operations.
