### PR TITLE
OpenCHAMI Weekly Digest: Nov 03–Nov 10, 2025

### DIFF
--- a/content/posts/weekly/2025-11-10.md
+++ b/content/posts/weekly/2025-11-10.md
@@ -1,0 +1,63 @@
+---
+title: "OpenCHAMI Weekly Digest: Nov 03–Nov 10, 2025"
+date: "2025-11-10T09:00:00"
+slug: "weekly-digest-2025-11-10"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# Weekly Highlights
+
+## Issues
+- [[Bug]: bss-init fails when invoking docker compose step in quickstart guide (x86-64_v3 minimum requirement ?)](https://github.com/OpenCHAMI/deployment-recipes/issues/142) in OpenCHAMI/deployment-recipes by @jlow2016
+- [[Feature]: Create Idempotent Update APIs for SMD](https://github.com/OpenCHAMI/smd/issues/79) in OpenCHAMI/smd by @erl-hpe
+- [[BUG] Legacy API endpoint `/boot/v1/bootparameters` does not allow backwards compatibility with BSS compatible clients](https://github.com/OpenCHAMI/boot-service/issues/1) in OpenCHAMI/boot-service by @davidallendj
+- [[RFD]: Add SerialConsole support SMD redfish support](https://github.com/OpenCHAMI/roadmap/issues/120) in OpenCHAMI/roadmap by @cjh1
+- [[RFD]: Issue Creation Policy](https://github.com/OpenCHAMI/roadmap/issues/117) in OpenCHAMI/roadmap by @jvd10
+- [[BUG] Unable to build compute image with image-build:v0.1.2 on the aarch64 node](https://github.com/OpenCHAMI/image-builder/issues/45) in OpenCHAMI/image-builder by @balajikumaran-c-s
+- [[BUG] Adding a BMC that already exists causes an error](https://github.com/OpenCHAMI/ochami/issues/55) in OpenCHAMI/ochami by @alexlovelltroy
+- [[RFD]: Hardware Inventory API and Data Model Proposal](https://github.com/OpenCHAMI/roadmap/issues/112) in OpenCHAMI/roadmap by @bmcdonald3
+- [Refactor OIDC mechanics](https://github.com/OpenCHAMI/tokensmith/issues/3) in OpenCHAMI/tokensmith by @alexlovelltroy
+- [[FEATURE] Support manifests for multi-arch images](https://github.com/OpenCHAMI/image-builder/issues/15) in OpenCHAMI/image-builder by @travisbcotton
+
+## Pull Requests
+- [OpenCHAMI Weekly Digest: Nov 03–Nov 10, 2025](https://github.com/OpenCHAMI/openchami.org/pull/46) in OpenCHAMI/openchami.org by @alexlovelltroy (state: closed)
+- [Multi Arch Support](https://github.com/OpenCHAMI/image-builder/pull/49) in OpenCHAMI/image-builder by @smehta99 (state: open)
+- [Bump to latest SMD images](https://github.com/OpenCHAMI/power-control/pull/55) in OpenCHAMI/power-control by @cjh1 (state: closed-merged)
+- [Add SerialConsole and CommandShell to RF](https://github.com/OpenCHAMI/smd/pull/81) in OpenCHAMI/smd by @cjh1 (state: open)
+- [Add support back for routing to old parseRedfishEndpoints when no schema present](https://github.com/OpenCHAMI/smd/pull/80) in OpenCHAMI/smd by @bmcdonald3 (state: closed-merged)
+- [fix(workflow): update permissions and improve token verification ](https://github.com/OpenCHAMI/community/pull/37) in OpenCHAMI/community by @alexlovelltroy (state: closed-merged)
+- [Docs/technical writer](https://github.com/OpenCHAMI/openchami.org/pull/45) in OpenCHAMI/openchami.org by @alexlovelltroy (state: open)
+- [feat(workflow): add weekly digest workflow for OpenCHAMI](https://github.com/OpenCHAMI/community/pull/36) in OpenCHAMI/community by @alexlovelltroy (state: closed-merged)
+- [chore(deps): bump helm/chart-testing-action from 2.7.0 to 2.8.0](https://github.com/OpenCHAMI/deployment-recipes/pull/141) in OpenCHAMI/deployment-recipes by @dependabot[bot] (state: open)
+- [Alovelltroy/fix workflow patch](https://github.com/OpenCHAMI/.github/pull/26) in OpenCHAMI/.github by @alexlovelltroy (state: closed-merged)
+- [Fix iconName formatting in simple test template properties](https://github.com/OpenCHAMI/.github/pull/25) in OpenCHAMI/.github by @alexlovelltroy (state: closed-merged)
+- [Move SPDX lines and add authorship](https://github.com/OpenCHAMI/fabrica/pull/21) in OpenCHAMI/fabrica by @alexlovelltroy (state: closed-merged)
+- [Feature/documentation blog](https://github.com/OpenCHAMI/fabrica/pull/20) in OpenCHAMI/fabrica by @alexlovelltroy (state: closed-merged)
+- [docs: reorganize documentation to prepare for improvements](https://github.com/OpenCHAMI/openchami.org/pull/44) in OpenCHAMI/openchami.org by @synackd (state: closed-merged)
+- [Refactor issue templates and workflows for consistency and clarity](https://github.com/OpenCHAMI/.github/pull/24) in OpenCHAMI/.github by @alexlovelltroy (state: closed-merged)
+- [Fix status update when not using versioning](https://github.com/OpenCHAMI/fabrica/pull/19) in OpenCHAMI/fabrica by @bmcdonald3 (state: closed-merged)
+- [Fix description formatting in bug report template](https://github.com/OpenCHAMI/.github/pull/23) in OpenCHAMI/.github by @alexlovelltroy (state: closed)
+- [chore: Update changelog and documentation for v0.3.1 release](https://github.com/OpenCHAMI/fabrica/pull/18) in OpenCHAMI/fabrica by @alexlovelltroy (state: closed-merged)
+- [feat: Implement per-resource spec versioning](https://github.com/OpenCHAMI/fabrica/pull/17) in OpenCHAMI/fabrica by @alexlovelltroy (state: closed-merged)
+- [Inventory blog](https://github.com/OpenCHAMI/openchami.org/pull/43) in OpenCHAMI/openchami.org by @bmcdonald3 (state: closed-merged)
+- [Added support for multiple nodes per BMC](https://github.com/OpenCHAMI/ochami/pull/62) in OpenCHAMI/ochami by @shunr-hpe (state: closed-merged)
+- [Integrate Casbin into middleware and remove built-in policy engine](https://github.com/OpenCHAMI/tokensmith/pull/6) in OpenCHAMI/tokensmith by @davidallendj (state: open)
+- [feat: add k8s_gateway plugin to coredns](https://github.com/OpenCHAMI/coresmd/pull/29) in OpenCHAMI/coresmd by @rainest (state: closed-merged)
+- [feat: add Docker build and release call workflow Action](https://github.com/OpenCHAMI/github-actions/pull/5) in OpenCHAMI/github-actions by @rainest (state: closed-merged)
+- [Removing templates](https://github.com/OpenCHAMI/.github/pull/22) in OpenCHAMI/.github by @alexlovelltroy (state: closed-merged)
+- [Renaming templates](https://github.com/OpenCHAMI/.github/pull/19) in OpenCHAMI/.github by @alexlovelltroy (state: closed)
+- [feat: add support for displaying power status](https://github.com/OpenCHAMI/ochami/pull/58) in OpenCHAMI/ochami by @cjh1 (state: open)
+- [Update contributing documentation and add REUSE compliance guidelines…](https://github.com/OpenCHAMI/.github/pull/14) in OpenCHAMI/.github by @alexlovelltroy (state: closed-merged)
+- [chore: add Delve Dockerfile](https://github.com/OpenCHAMI/cloud-init/pull/95) in OpenCHAMI/cloud-init by @rainest (state: closed-merged)
+- [Adr/006 api contract](https://github.com/OpenCHAMI/community/pull/34) in OpenCHAMI/community by @alexlovelltroy (state: closed-merged)
+- [Add ADR 004 for renaming services](https://github.com/OpenCHAMI/community/pull/33) in OpenCHAMI/community by @alexlovelltroy (state: open)
+- [adr for merge policy (informally) accepted during dev summit 25](https://github.com/OpenCHAMI/community/pull/32) in OpenCHAMI/community by @jvd10 (state: open)
+- [feat: create baremetal guide](https://github.com/OpenCHAMI/deployment-recipes/pull/136) in OpenCHAMI/deployment-recipes by @t-h2o (state: open)
+- [Create 002-API-Versioning.md](https://github.com/OpenCHAMI/community/pull/27) in OpenCHAMI/community by @haroldlongley (state: open)
+
+## Releases
+- OpenCHAMI/ochami v0.5.6 (v0.5.6) - https://github.com/OpenCHAMI/ochami/releases/tag/v0.5.6
+- OpenCHAMI/fabrica v0.3.1 (v0.3.1) - https://github.com/OpenCHAMI/fabrica/releases/tag/v0.3.1
+
+_Generated without LLM due to model error or empty input_


### PR DESCRIPTION
This PR adds the weekly digest post generated on 2025-11-10.

- Post path: `content/posts/weekly/2025-11-10.md`
- Slug: `weekly-digest-2025-11-10`

Please review copy and publish.
