### PR TITLE
OpenCHAMI Weekly Digest: Nov 03–Nov 10, 2025

### DIFF
--- a/content/posts/weekly/2025-11-10.md
+++ b/content/posts/weekly/2025-11-10.md
@@ -1,0 +1,63 @@
+---
+title: "OpenCHAMI Weekly Digest: Nov 03–Nov 10, 2025"
+date: "2025-11-10T09:00:00"
+slug: "weekly-digest-2025-11-10"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+```markdown
+# OpenCHAMI Weekly Digest: Nov 03–Nov 10, 2025
+
+## Highlights
+- **Multi-architecture support advancing:** Image Builder continues to expand with a new open PR for multi-arch manifests ([#49](https://github.com/OpenCHAMI/image-builder/pull/49)) and an enhancement issue focused on multi-arch image manifests ([#15](https://github.com/OpenCHAMI/image-builder/issues/15)).
+- **Improved SMD APIs:** Feature request for idempotent update APIs in SMD is open, alongside active work adding SerialConsole and CommandShell support to Redfish ([Feature #79](https://github.com/OpenCHAMI/smd/issues/79), PR [#81](https://github.com/OpenCHAMI/smd/pull/81)).
+- **Power control updates:** Latest SMD images integrated via a merged PR, boosting stability and capabilities ([PR #55](https://github.com/OpenCHAMI/power-control/pull/55)).
+- **Deployment recipes bug identified:** A reported issue with `bss-init` failing in the quickstart guide related to docker compose and architecture requirements ([#142](https://github.com/OpenCHAMI/deployment-recipes/issues/142)).
+- **OpenCHAMI/ochami release v0.5.6:** New version delivered with bug fixes and improvements; also addressing BMC addition errors ([v0.5.6 release](https://github.com/OpenCHAMI/ochami/releases/tag/v0.5.6), Issue [#55](https://github.com/OpenCHAMI/ochami/issues/55)).
+- **Boot Service API backward compatibility issue:** Legacy endpoint `/boot/v1/bootparameters` not fully compatible with BSS clients, pending resolution ([#1](https://github.com/OpenCHAMI/boot-service/issues/1)).
+- **Roadmap planning:** Proposals for Hardware Inventory API and SerialConsole Redfish support show focus on deeper hardware & system management integration ([#112](https://github.com/OpenCHAMI/roadmap/issues/112), [#120](https://github.com/OpenCHAMI/roadmap/issues/120)).
+- **Community improvements:** Workflow updates enhance token verification and automation with a new weekly digest workflow merged ([#37](https://github.com/OpenCHAMI/community/pull/37), [#36](https://github.com/OpenCHAMI/community/pull/36)).
+- **Documentation progress:** Ongoing efforts to enhance technical writing are visible with an open docs-focused PR ([#45](https://github.com/OpenCHAMI/openchami.org/pull/45)).
+
+## New & Notable PRs
+- [Multi Arch Support](https://github.com/OpenCHAMI/image-builder/pull/49) (Image Builder) — Adds multi-architecture support for image manifests.
+- [Add SerialConsole and CommandShell to RF](https://github.com/OpenCHAMI/smd/pull/81) (SMD) — Extends Redfish support for consoles.
+- [Add support back for routing to old parseRedfishEndpoints](https://github.com/OpenCHAMI/smd/pull/80) (SMD) — Improves backward compatibility.
+- [Bump to latest SMD images](https://github.com/OpenCHAMI/power-control/pull/55) (Power Control) — Updates components for better stability.
+- [Fix workflow permissions and improve token verification](https://github.com/OpenCHAMI/community/pull/37) (Community) — Security and automation enhancements.
+
+## Issues to Watch
+- [bss-init fails during docker compose step](https://github.com/OpenCHAMI/deployment-recipes/issues/142) — Potential blocker for quickstart users on x86-64.
+- [Legacy Boot Service API not backward compatible](https://github.com/OpenCHAMI/boot-service/issues/1) — Could affect systems relying on older BSS clients.
+- [Building compute image fails on aarch64 nodes](https://github.com/OpenCHAMI/image-builder/issues/45) — Critical bug for ARM64 architecture users.
+- [Adding duplicate BMC causes errors](https://github.com/OpenCHAMI/ochami/issues/55) — Could impact device management workflows.
+- [Hardware Inventory API proposal](https://github.com/OpenCHAMI/roadmap/issues/112) — Signals upcoming improvements in hardware data modeling.
+
+## Releases
+- [ochami v0.5.6](https://github.com/OpenCHAMI/ochami/releases/tag/v0.5.6) — Includes bug fixes and refinements to BMC handling.
+- [fabrica v0.3.1](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.3.1) — Minor release with stability improvements.
+
+## Contributor Thanks
+Thanks to everyone driving progress this week, including:  
+- **alexlovelltroy** for multiple PRs and docs updates  
+- **cjh1** for contributions to SMD and power-control  
+- **smehta99** for multi-arch support work  
+- **bmcdonald3** and **jlow2016** for active issue reporting and feature proposals
+
+---
+
+## What’s Next
+- Resolve critical bugs impacting deployment and image-building on diverse architectures.  
+- Finalize and merge multi-architecture image builder improvements.  
+- Implement proposed Hardware Inventory APIs for better system hardware insights.  
+- Expand Redfish SerialConsole and CommandShell support to improve management capabilities.  
+- Continue improving documentation and automation workflows for better community engagement.
+
+## Proposed Blog Titles
+- "Unlocking Multi-Architecture Support: What’s New in OpenCHAMI Image Builder"  
+- "SMD’s Next Steps: Idempotent APIs and Enhanced Redfish Console Support"  
+- "Spotlight on Stability: Bug Fixes and Releases in OpenCHAMI v0.5.6"  
+- "Behind the Scenes: How We’re Improving OpenCHAMI’s Deployment Experience"  
+- "Community & Automation: New Workflows Powering OpenCHAMI Development"
+```


### PR DESCRIPTION
This PR adds the weekly digest post generated on 2025-11-10.

- Post path: `content/posts/weekly/2025-11-10.md`
- Slug: `weekly-digest-2025-11-10`

Please review copy and publish.
