### PR TITLE
seantronsen/replace minio

### DIFF
--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -893,8 +893,8 @@ EOF
 This will allow the resolution of node hostnames, e.g. `de01.openchami.cluster`.
 
 {{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
-Users should be aware of potential port conflicts if the installation target is
-already running similar network services. Although, CoreDNS cannot bind to
+**If running an existing DNS server, be aware of potential port conflicts for port 53!**
+Although, CoreDNS cannot bind to
 in-use IP/port combinations, it may be configured to forward queries to the
 existing DNS server instead. If you encounter a port conflict, CoreDNS is not a
 required service dependency and can be safely disabled; however, doing so means

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -2202,7 +2202,16 @@ build-image-rh9()
         echo "$1 does not exist." 1>&2;
         return 1;
     fi;
-    source <(sudo cat /etc/versitygw/secrets.env);
+    if [ -z "${ROOT_ACCESS_KEY:-}" ]; then
+      echo "ROOT_ACCESS_KEY is not set" 1>&2;
+      echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+      return 1;
+    fi
+    if [ -z "${ROOT_SECRET_KEY:-}" ]; then
+      echo "ROOT_SECRET_KEY is not set" 1>&2;
+      echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+      return 1;
+    fi
     podman run \
             --rm \
             --device /dev/fuse \
@@ -2226,7 +2235,16 @@ build-image-rh8()
         echo "$1 does not exist." 1>&2;
         return 1;
     fi;
-    source <(sudo cat /etc/versitygw/secrets.env);
+    if [ -z "${ROOT_ACCESS_KEY:-}" ]; then
+      echo "ROOT_ACCESS_KEY is not set" 1>&2;
+      echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+      return 1;
+    fi
+    if [ -z "${ROOT_SECRET_KEY:-}" ]; then
+      echo "ROOT_SECRET_KEY is not set" 1>&2;
+      echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+      return 1;
+    fi
     podman run \
            --rm \
            --device /dev/fuse \
@@ -2275,7 +2293,16 @@ alias build-image='build-image-rh9'
                 echo "$1 does not exist." 1>&2;
                 return 1;
             fi;
-            source <(sudo cat /etc/versitygw/secrets.env);
+            if [ -z "${ROOT_ACCESS_KEY:-}" ]; then
+              echo "ROOT_ACCESS_KEY is not set" 1>&2;
+              echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+              return 1;
+            fi
+            if [ -z "${ROOT_SECRET_KEY:-}" ]; then
+              echo "ROOT_SECRET_KEY is not set" 1>&2;
+              echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+              return 1;
+            fi
             podman run --rm --device /dev/fuse -e S3_ACCESS="${ROOT_ACCESS_KEY}" -e S3_SECRET="${ROOT_SECRET_KEY}" -v "$(realpath $1)":/home/builder/config.yaml:Z ${EXTRA_PODMAN_ARGS} ghcr.io/openchami/image-build-el9:v0.1.2 image-build --config config.yaml --log-level DEBUG
         }
 ```

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -2962,8 +2962,8 @@ They should match the file above:
         pub_key_ecdsa: ""
         pub_key_rsa: ""
     user-data: null
-  initrd: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-611.24.1.el9_7.x86_64.img'
-  kernel: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-611.24.1.el9_7.x86_64'
+  initrd: http://172.16.0.254:7070/boot-images/efi-images/compute/base/initramfs-5.14.0-611.24.1.el9_7.x86_64.img
+  kernel: http://172.16.0.254:7070/boot-images/efi-images/compute/base/vmlinuz-5.14.0-611.24.1.el9_7.x86_64
   macs:
     - 52:54:00:be:ef:01
     - 52:54:00:be:ef:02

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -893,8 +893,7 @@ EOF
 This will allow the resolution of node hostnames, e.g. `de01.openchami.cluster`.
 
 {{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
-**If running an existing DNS server, be aware of potential port conflicts for
-port 53!** Although, CoreDNS cannot bind to in-use IP/port combinations, it may
+port 53!** Although CoreDNS cannot bind to in-use IP/port combinations, it may
 be configured to forward queries to the existing DNS server instead. If you
 encounter a port conflict, CoreDNS is not a required service dependency and can
 be safely disabled; however, doing so means name resolution for nodes/BMCs will

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -893,15 +893,15 @@ EOF
 This will allow the resolution of node hostnames, e.g. `de01.openchami.cluster`.
 
 {{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
-**If running an existing DNS server, be aware of potential port conflicts for port 53!**
-Although, CoreDNS cannot bind to
-in-use IP/port combinations, it may be configured to forward queries to the
-existing DNS server instead. If you encounter a port conflict, CoreDNS is not a
-required service dependency and can be safely disabled; however, doing so means
-name resolution for nodes/BMCs will not function and you will need to manage
-node hostnames manually. A lower-friction alternative that preserves DNS
-functionality is to change the CoreDNS configuration to use an unused port like
-`1053` and manually specify that port to any DNS dependent CLI tools.
+**If running an existing DNS server, be aware of potential port conflicts for
+port 53!** Although, CoreDNS cannot bind to in-use IP/port combinations, it may
+be configured to forward queries to the existing DNS server instead. If you
+encounter a port conflict, CoreDNS is not a required service dependency and can
+be safely disabled; however, doing so means name resolution for nodes/BMCs will
+not function and you will need to manage node hostnames manually. A
+lower-friction alternative that preserves DNS functionality is to change the
+CoreDNS configuration to use an unused port like `1053` and manually specify
+that port to any DNS dependent CLI tools.
 {{< /callout >}}
 
 ### 1.5 Configure Cluster FQDN for Certificates

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -103,7 +103,7 @@ packages:
 # Post-package installation commands
 runcmd:
   - dnf install -y epel-release
-  - dnf install -y s3cmd
+  - dnf install -y s3cmd awscli
   - systemctl enable --now libvirtd
   - newgrp libvirt
   - usermod -aG libvirt rocky
@@ -173,7 +173,7 @@ write_files:
 # Post-package installation commands
 runcmd:
   - dnf install -y epel-release
-  - dnf install -y s3cmd
+  - dnf install -y s3cmd awscli
   - systemctl enable --now libvirtd
   - newgrp libvirt
   - usermod -aG libvirt rocky
@@ -192,6 +192,7 @@ Setup is similar to the cloud instance setups above. Ensure the following
 packages are installed (Red Hat package names used):
 
 - ansible-core
+- awscli
 - buildah
 - dnsmasq
 - git
@@ -342,7 +343,7 @@ grubby --update-kernel=ALL --args='console=ttyS0,115200n8 systemd.unified_cgroup
 grub2-mkconfig -o /etc/grub2.cfg
 # Enable mounting /tmp as tmpfs
 systemctl enable tmp.mount
-dnf install -y vim s3cmd
+dnf install -y vim s3cmd awscli
 %end
 
 reboot

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -2204,12 +2204,12 @@ build-image-rh9()
     fi;
     if [ -z "${ROOT_ACCESS_KEY:-}" ]; then
       echo "ROOT_ACCESS_KEY is not set" 1>&2;
-      echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+      echo "S3 credentials not loaded. Run: source <(sudo cat /etc/versitygw/secrets.env)" 1>&2;
       return 1;
     fi
     if [ -z "${ROOT_SECRET_KEY:-}" ]; then
       echo "ROOT_SECRET_KEY is not set" 1>&2;
-      echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+      echo "S3 credentials not loaded. Run: source <(sudo cat /etc/versitygw/secrets.env)" 1>&2;
       return 1;
     fi
     podman run \
@@ -2237,12 +2237,12 @@ build-image-rh8()
     fi;
     if [ -z "${ROOT_ACCESS_KEY:-}" ]; then
       echo "ROOT_ACCESS_KEY is not set" 1>&2;
-      echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+      echo "S3 credentials not loaded. Run: source <(sudo cat /etc/versitygw/secrets.env)" 1>&2;
       return 1;
     fi
     if [ -z "${ROOT_SECRET_KEY:-}" ]; then
       echo "ROOT_SECRET_KEY is not set" 1>&2;
-      echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+      echo "S3 credentials not loaded. Run: source <(sudo cat /etc/versitygw/secrets.env)" 1>&2;
       return 1;
     fi
     podman run \
@@ -2295,12 +2295,12 @@ alias build-image='build-image-rh9'
             fi;
             if [ -z "${ROOT_ACCESS_KEY:-}" ]; then
               echo "ROOT_ACCESS_KEY is not set" 1>&2;
-              echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+              echo "S3 credentials not loaded. Run: source <(sudo cat /etc/versitygw/secrets.env)" 1>&2;
               return 1;
             fi
             if [ -z "${ROOT_SECRET_KEY:-}" ]; then
               echo "ROOT_SECRET_KEY is not set" 1>&2;
-              echo "S3 credentials not loaded. Run: source <path-to-credentials>" 1>&2;
+              echo "S3 credentials not loaded. Run: source <(sudo cat /etc/versitygw/secrets.env)" 1>&2;
               return 1;
             fi
             podman run --rm --device /dev/fuse -e S3_ACCESS="${ROOT_ACCESS_KEY}" -e S3_SECRET="${ROOT_SECRET_KEY}" -v "$(realpath $1)":/home/builder/config.yaml:Z ${EXTRA_PODMAN_ARGS} ghcr.io/openchami/image-build-el9:v0.1.2 image-build --config config.yaml --log-level DEBUG

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -1060,15 +1060,15 @@ ochami version
 The output should look something like:
 
 ```
-Version:    0.5.5
-Tag:        v0.5.5
+Version:    0.6.0
+Tag:        v0.6.0
 Branch:     HEAD
-Commit:     459036212f075fdac417715797843ba21fda6238
+Commit:     2243fa5a8b1b47667b0e2c662397fbc5c1761627
 Git State:  clean
-Date:       2025-10-09T17:11:23Z
-Go:         go1.25.2
+Date:       2025-11-25T16:13:22Z
+Go:         go1.25.4
 Compiler:   gc
-Build Host: runnervmwhb2z
+Build Host: runnervmg1sw1
 Build User: runner
 ```
 

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -898,7 +898,7 @@ already running similar network services. Although, CoreDNS cannot bind to
 in-use IP/port combinations, it may be configured to forward queries to the
 existing DNS server instead. If you encounter a port conflict, CoreDNS is not a
 required service dependency and can be safely disabled; however, doing so means
-name resolution will not function and you will need to manage node hostnames
+name resolution for nodes/BMCs will not function and you will need to manage node hostnames
 manually. A lower-friction alternative that preserves DNS functionality is to
 change the CoreDNS configuration to use an unused port like `1053` and manually
 specify that port to any DNS dependent CLI tools.

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -615,8 +615,9 @@ cat <<EOF > openchami-net.xml
   <name>openchami-net</name>
   <bridge name="virbr-openchami" />
   <forward mode='route'/>
-   <ip address="172.16.0.254" netmask="255.255.255.0">
-   </ip>
+  <dns enable='no'/>
+  <ip address="172.16.0.254" netmask="255.255.255.0">
+  </ip>
 </network>
 EOF
 
@@ -845,7 +846,7 @@ Update the CoreDNS config as well:
 
 ```bash
 cat <<EOF | sudo tee /etc/openchami/configs/Corefile
-.:1053 {
+.:53 {
     # Enable readiness endpoint.
     ready
 

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -892,7 +892,7 @@ EOF
 
 This will allow the resolution of node hostnames, e.g. `de01.openchami.cluster`.
 
-{{< callout context="note" title="Note" icon="outline/info-circle" >}}
+{{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
 Users should be aware of potential port conflicts if the installation target is
 already running similar network services. Although, CoreDNS cannot bind to
 in-use IP/port combinations, it may be configured to forward queries to the

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -1471,6 +1471,7 @@ The output should be:
   "ID": "x1000c0s0b0n0",
   "NID": 1,
   "Role": "Compute",
+  "State": "On",
   "Type": "Node"
 }
 {
@@ -1478,6 +1479,7 @@ The output should be:
   "ID": "x1000c0s0b1n0",
   "NID": 2,
   "Role": "Compute",
+  "State": "On",
   "Type": "Node"
 }
 {
@@ -1485,6 +1487,7 @@ The output should be:
   "ID": "x1000c0s0b2n0",
   "NID": 3,
   "Role": "Compute",
+  "State": "On",
   "Type": "Node"
 }
 {
@@ -1492,6 +1495,7 @@ The output should be:
   "ID": "x1000c0s0b3n0",
   "NID": 4,
   "Role": "Compute",
+  "State": "On",
   "Type": "Node"
 }
 {
@@ -1499,6 +1503,7 @@ The output should be:
   "ID": "x1000c0s0b4n0",
   "NID": 5,
   "Role": "Compute",
+  "State": "On",
   "Type": "Node"
 }
 ```

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -898,10 +898,10 @@ already running similar network services. Although, CoreDNS cannot bind to
 in-use IP/port combinations, it may be configured to forward queries to the
 existing DNS server instead. If you encounter a port conflict, CoreDNS is not a
 required service dependency and can be safely disabled; however, doing so means
-name resolution for nodes/BMCs will not function and you will need to manage node hostnames
-manually. A lower-friction alternative that preserves DNS functionality is to
-change the CoreDNS configuration to use an unused port like `1053` and manually
-specify that port to any DNS dependent CLI tools.
+name resolution for nodes/BMCs will not function and you will need to manage
+node hostnames manually. A lower-friction alternative that preserves DNS
+functionality is to change the CoreDNS configuration to use an unused port like
+`1053` and manually specify that port to any DNS dependent CLI tools.
 {{< /callout >}}
 
 ### 1.5 Configure Cluster FQDN for Certificates

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -1957,8 +1957,8 @@ podman run \
   --rm \
   --device /dev/fuse \
   --network host \
-  -e S3_ACCESS=admin \
-  -e S3_SECRET=admin123 \
+  -e S3_ACCESS="${ROOT_ACCESS_KEY}" \
+  -e S3_SECRET="${ROOT_SECRET_KEY}" \
   -v /etc/openchami/data/images/compute-base-rocky9.yaml:/home/builder/config.yaml \
   ghcr.io/openchami/image-build-el9:v0.1.2 \
   image-build \
@@ -1967,7 +1967,16 @@ podman run \
 ```
 
 Note that this time, `S3_ACCESS` and `S3_SECRET` are set to authenticate to
-Minio. These are needed whenever pushing an image to S3.
+Versity S3 Gateway. These are needed whenever pushing an image to S3.
+
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
+If you find yourself with the error "The AWS Access Key Id you provided does
+not exist in our records.", determine whether values have been set for
+environment variables `ROOT_ACCESS_KEY` and `ROOT_SECRET_KEY` by observing the
+output of `env | grep KEY`. If no definitions exist for these variables, re-run
+the following command to pull them back in: `source <(sudo cat
+/etc/versitygw/secrets.env)`.
+{{< /callout >}}
 
 This won't take as long as the base image since the only thing being done is
 installing packages on top of the already-built filesystem. This time, since
@@ -2111,8 +2120,8 @@ Build this image:
 podman run \
   --rm \
   --device /dev/fuse \
-  -e S3_ACCESS=admin \
-  -e S3_SECRET=admin123 \
+  -e S3_ACCESS="${ROOT_ACCESS_KEY}" \
+  -e S3_SECRET="${ROOT_SECRET_KEY}" \
   -v /etc/openchami/data/images/compute-debug-rocky9.yaml:/home/builder/config.yaml \
   ghcr.io/openchami/image-build-el9:v0.1.2 \
   image-build \
@@ -2181,11 +2190,12 @@ build-image-rh9()
         echo "$1 does not exist." 1>&2;
         return 1;
     fi;
+    source <(sudo cat /etc/versitygw/secrets.env);
     podman run \
             --rm \
             --device /dev/fuse \
-            -e S3_ACCESS=admin \
-            -e S3_SECRET=admin123 \
+            -e S3_ACCESS="${ROOT_ACCESS_KEY}" \
+            -e S3_SECRET="${ROOT_SECRET_KEY}" \
             -v "$(realpath $1)":/home/builder/config.yaml:Z \
             ${EXTRA_PODMAN_ARGS} \
             ghcr.io/openchami/image-build-el9:v0.1.2 \
@@ -2204,11 +2214,12 @@ build-image-rh8()
         echo "$1 does not exist." 1>&2;
         return 1;
     fi;
+    source <(sudo cat /etc/versitygw/secrets.env);
     podman run \
            --rm \
            --device /dev/fuse \
-           -e S3_ACCESS=admin \
-           -e S3_SECRET=admin123 \
+           -e S3_ACCESS="${ROOT_ACCESS_KEY}" \
+           -e S3_SECRET="${ROOT_SECRET_KEY}" \
            -v "$(realpath $1)":/home/builder/config.yaml:Z \
            ${EXTRA_PODMAN_ARGS} \
            ghcr.io/openchami/image-build:v0.1.2 \
@@ -2252,7 +2263,8 @@ alias build-image='build-image-rh9'
                 echo "$1 does not exist." 1>&2;
                 return 1;
             fi;
-            podman run --rm --device /dev/fuse -e S3_ACCESS=admin -e S3_SECRET=admin123 -v "$(realpath $1)":/home/builder/config.yaml:Z ${EXTRA_PODMAN_ARGS} ghcr.io/openchami/image-build-el9:v0.1.2 image-build --config config.yaml --log-level DEBUG
+            source <(sudo cat /etc/versitygw/secrets.env);
+            podman run --rm --device /dev/fuse -e S3_ACCESS="${ROOT_ACCESS_KEY}" -e S3_SECRET="${ROOT_SECRET_KEY}" -v "$(realpath $1)":/home/builder/config.yaml:Z ${EXTRA_PODMAN_ARGS} ghcr.io/openchami/image-build-el9:v0.1.2 image-build --config config.yaml --log-level DEBUG
         }
 ```
 

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -1999,7 +1999,7 @@ the image is being pushed to S3 (and `--log-level DEBUG` was passed) _a lot_ of
 S3 output will be seen. The following should appear:
 
 ```
-Pushing /var/tmp/tmpda2ddyh0/rootfs as compute/base/rocky9.6-compute-base-rocky9 to boot-images
+Pushing /var/tmp/tmpda2ddyh0/rootfs as compute/base/rocky9.7-compute-base-rocky9 to boot-images
 pushing layer compute-base to demo.openchami.cluster:5000/demo/compute-base:rocky9
 ```
 
@@ -2012,9 +2012,9 @@ Note that the format of the image name being pushed to S3 is:
 In this case:
 
 - `<distro>` is `rocky`
-- `<version>` is `9.6`
+- `<version>` is `9.7`
 - `<name>` is `compute-base` (from `name` field in image config file)
-- `<tag>` is `rocky9.6` (from `publish_tags` in image config file, there can be multiple)
+- `<tag>` is `rocky9.7` (from `publish_tags` in image config file, there can be multiple)
 
 Verify that the image has been created and stored in the registry:
 
@@ -2050,16 +2050,16 @@ s3cmd ls -Hr s3://boot-images | cut -d' ' -f 4- | grep compute/base
 The output should be akin to:
 
 ```
-1436M  s3://boot-images/compute/base/rocky9.6-compute-base-rocky9
-  82M  s3://boot-images/efi-images/compute/base/initramfs-5.14.0-570.26.1.el9_6.x86_64.img
-  14M  s3://boot-images/efi-images/compute/base/vmlinuz-5.14.0-570.26.1.el9_6.x86_64
+1557M  s3://boot-images/compute/base/rocky9.7-compute-base-rocky9
+  84M  s3://boot-images/efi-images/compute/base/initramfs-5.14.0-611.24.1.el9_7.x86_64.img
+  14M  s3://boot-images/efi-images/compute/base/vmlinuz-5.14.0-611.24.1.el9_7.x86_64
 ```
 
 Note the following:
 
-- SquashFS image: `s3://boot-images/compute/base/rocky9.6-compute-base-rocky9`
-- Initramfs: `s3://boot-images/efi-images/compute/base/initramfs-5.14.0-570.26.1.el9_6.x86_64.img`
-- Kernel: `s3://boot-images/efi-images/compute/base/vmlinuz-5.14.0-570.26.1.el9_6.x86_64`
+- SquashFS image: `s3://boot-images/compute/base/rocky9.7-compute-base-rocky9`
+- Initramfs: `s3://boot-images/efi-images/compute/base/initramfs-5.14.0-611.24.1.el9_7.x86_64.img`
+- Kernel: `s3://boot-images/efi-images/compute/base/vmlinuz-5.14.0-611.24.1.el9_7.x86_64`
 
 #### 2.4.5 Configure the Debug Image
 
@@ -2156,12 +2156,12 @@ The output should be akin to (note that the base image is not here because it
 wasn't pushed to S3, only the registry):
 
 ```
-1436M  s3://boot-images/compute/base/rocky9.6-compute-base-rocky9
-1437M  s3://boot-images/compute/debug/rocky9.6-compute-debug-rocky9
-  82M  s3://boot-images/efi-images/compute/base/initramfs-5.14.0-570.26.1.el9_6.x86_64.img
-  14M  s3://boot-images/efi-images/compute/base/vmlinuz-5.14.0-570.26.1.el9_6.x86_64
-  82M  s3://boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img
-  14M  s3://boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64
+1557M  s3://boot-images/compute/base/rocky9.7-compute-base-rocky9
+1557M  s3://boot-images/compute/debug/rocky9.7-compute-debug-rocky9
+  84M  s3://boot-images/efi-images/compute/base/initramfs-5.14.0-611.24.1.el9_7.x86_64.img
+  14M  s3://boot-images/efi-images/compute/base/vmlinuz-5.14.0-611.24.1.el9_7.x86_64
+  84M  s3://boot-images/efi-images/compute/debug/initramfs-5.14.0-611.24.1.el9_7.x86_64.img
+  14M  s3://boot-images/efi-images/compute/debug/vmlinuz-5.14.0-611.24.1.el9_7.x86_64
 ```
 
 A kernel, initramfs, and SquashFS should be visible for each image that was built.
@@ -2379,7 +2379,7 @@ over time. Be sure to update with the output of `s3cmd ls` as stated above!
 ```yaml
 kernel: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-611.24.1.el9_7.x86_64'
 initrd: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-611.24.1.el9_7.x86_64.img'
-params: 'nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init'
+params: 'nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.7-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init'
 macs:
   - 52:54:00:be:ef:01
   - 52:54:00:be:ef:02
@@ -2429,7 +2429,7 @@ The output should be akin to:
     - 52:54:00:be:ef:03
     - 52:54:00:be:ef:04
     - 52:54:00:be:ef:05
-  params: nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init
+  params: nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.7-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init
 ```
 
 The things to check are:
@@ -2460,7 +2460,7 @@ be the same values from section 2.5.2.a but in JSON.
     "52:54:00:be:ef:04",
     "52:54:00:be:ef:05"
   ],
-  "params": "nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init",
+  "params": "nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.7-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init",
   "kernel": "http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-611.24.1.el9_7.x86_64",
   "initrd": "http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-611.24.1.el9_7.x86_64.img",
 
@@ -2625,8 +2625,8 @@ BdsDxe: failed to load Boot0001 "UEFI PXEv4 (MAC:525400BEEF01)" from PciRoot(0x0
 Once the login prompt appears:
 
 ```
-Rocky Linux 9.6 (Blue Onyx)
-Kernel 5.14.0-570.21.1.el9_6.x86_64 on x86_64
+Rocky Linux 9.7 (Blue Onyx)
+Kernel 5.14.0-611.24.1.el9_7.x86_64 on x86_64
 
 nid0001 login:
 ```
@@ -2907,9 +2907,9 @@ s3cmd ls -Hr s3://boot-images/ | awk '{print $4}' | grep compute/base
 The output should look something like (versions will likely be different):
 
 ```
-s3://boot-images/compute/base/rocky9.6-compute-base-rocky9
-s3://boot-images/efi-images/compute/base/initramfs-5.14.0-570.21.1.el9_6.x86_64.img
-s3://boot-images/efi-images/compute/base/vmlinuz-5.14.0-570.21.1.el9_6.x86_64
+s3://boot-images/compute/base/rocky9.7-compute-base-rocky9
+s3://boot-images/efi-images/compute/base/initramfs-5.14.0-611.24.1.el9_7.x86_64.img
+s3://boot-images/efi-images/compute/base/vmlinuz-5.14.0-611.24.1.el9_7.x86_64
 ```
 
 Create `boot-compute-rocky9.yaml` with these values, using the same method used
@@ -2970,7 +2970,7 @@ They should match the file above:
     - 52:54:00:be:ef:03
     - 52:54:00:be:ef:04
     - 52:54:00:be:ef:05
-  params: nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/base/rocky9.6-compute-base-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init
+  params: nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/base/rocky9.7-compute-base-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init
 ```
 
 #### 2.8.2 Booting the Compute Node

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -893,13 +893,15 @@ EOF
 This will allow the resolution of node hostnames, e.g. `de01.openchami.cluster`.
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
-The default `Corefile` provided with the installation serves primarily as a
-template and without these changes, the `coredns` service will fail to start. In
-summary, above we reconfigure the port assignment to avoid conflicts with
-existing services like `dnsmasq` and `aardvark` while also ensuring an endpoint
-has been configured for `smd_url`. Understand that `coredns` may also be
-configured to forward requests to existing servers, but that is outside of the
-scope of this tutorial.
+Users should be aware of potential port conflicts if the installation target is
+already running similar network services. Although, CoreDNS cannot bind to
+in-use IP/port combinations, it may be configured to forward queries to the
+existing DNS server instead. If you encounter a port conflict, CoreDNS is not a
+required service dependency and can be safely disabled; however, doing so means
+name resolution will not function and you will need to manage node hostnames
+manually. A lower-friction alternative that preserves DNS functionality is to
+change the CoreDNS configuration to use an unused port like `1053` and manually
+specify that port to any DNS dependent CLI tools.
 {{< /callout >}}
 
 ### 1.5 Configure Cluster FQDN for Certificates

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -657,11 +657,12 @@ For the S3 gateway, this tutorial uses a pre-built RPM to install and configure
 deployment as a quadlet.
 
 ```bash
-# Download the latest release RPM
-curl -LO $(curl -s https://api.github.com/repos/openchami/versitygw-quadlet/releases/latest | grep "browser_download_url.*\.rpm" | grep -v "\.src\.rpm" | cut -d '"' -f 4)
-
+# Get latest release RPM URL
+latest_versity_url=$(curl -s https://api.github.com/repos/openchami/versitygw-quadlet/releases/latest | jq -r '.assets[] | select(.name | endswith("'"$(rpm --eval '%dist')"'.noarch.rpm")) | .browser_download_url')
+# Download RPM
+curl -L "${latest_versity_url}" -o versitygw.rpm
 # Install the RPM
-sudo dnf install ./versitygw-quadlet-*.noarch.rpm
+sudo dnf install ./versitygw.rpm
 ```
 
 #### 1.3.2 Container Registry

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -1675,10 +1675,39 @@ List the S3 buckets (removing the timestamps):
 s3cmd ls | cut -d' ' -f 4-
 ```
 
-The output should be:
+In addition to the default buckets created when we installed the RPM for
+`versitygw`, the output should include:
 
 ```
 s3://boot-images
+```
+
+You can obtain more information using `s3cmd info <bucket-name>`. For example,
+with `s3cmd info s3://boot-images`:
+
+```
+s3://boot-images/ (bucket):
+   Location:  us-east-1
+   Payer:     none
+   Ownership: BucketOwnerPreferred
+   Versioning:none
+   Expiration rule: none
+   Block Public Access: none
+   Policy:    {
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Effect":"Allow",
+      "Principal":"*",
+      "Action":["s3:GetObject"],
+      "Resource":["arn:aws:s3:::boot-images/*"]
+    }
+  ]
+}
+
+   CORS:      none
+   ACL:       1b835f0cce711c0ab5668c05afaff93d: FULL_CONTROL
+   ACL:       all-users: READ
 ```
 
 ### 2.4 Building System Images

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -895,8 +895,10 @@ This will allow the resolution of node hostnames, e.g. `de01.openchami.cluster`.
 The default `Corefile` provided with the installation serves primarily as a
 template and without these changes, the `coredns` service will fail to start. In
 summary, above we reconfigure the port assignment to avoid conflicts with
-`dnsmasq` and `aardvark` while also ensuring an endpoint has been configured for
-`smd_url`.
+existing services like `dnsmasq` and `aardvark` while also ensuring an endpoint
+has been configured for `smd_url`. Understand that `coredns` may also be
+configured to forward requests to existing servers, but that is outside of the
+scope of this tutorial.
 {{< /callout >}}
 
 ### 1.5 Configure Cluster FQDN for Certificates

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -3072,10 +3072,10 @@ OpenCHAMI to fit one's own needs.
 
 ### 3.1 Serve Images Using NFS Instead of HTTP
 
-For this tutorial, images were served via HTTP using a local S3 bucket (MinIO)
-and OCI registry. Instead, images could be mounted over NFS by setting up and
-running a NFS server on the head node, including NFS tools in the base image,
-and configuring the nodes to work with NFS.
+For this tutorial, images were served via HTTP using a local S3 bucket (Versity
+S3 Gateway) and OCI registry. Instead, images could be mounted over NFS by
+setting up and running a NFS server on the head node, including NFS tools in
+the base image, and configuring the nodes to work with NFS.
 
 ### 3.2 Customize Boot Image and Operating System
 

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -1626,14 +1626,15 @@ Create a `boot-images` bucket to store the images that are built:
 
 ```bash
 s3cmd mb s3://boot-images
-s3cmd setacl s3://boot-images --acl-public
+s3cmd setownership s3://boot-images BucketOwnerPreferred
+aws s3api put-bucket-acl --bucket boot-images --acl public-read --endpoint-url http://localhost:7070
 ```
 
 The output should be:
 
 ```
 Bucket 's3://boot-images/' created
-s3://boot-images/: ACL set to Public
+s3://boot-images/: Bucket Object Ownership updated
 ```
 
 Set the policy to allow public downloads from the `boot-images` bucket:
@@ -1658,8 +1659,8 @@ Apply the policy in S3:
 
 ```bash
 s3cmd setpolicy /opt/workdir/s3-public-read-boot.json s3://boot-images \
-    --host=172.16.0.254:9000 \
-    --host-bucket=172.16.0.254:9000
+    --host=172.16.0.254:7070 \
+    --host-bucket=172.16.0.254:7070
 ```
 
 The output should be:

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -2373,8 +2373,8 @@ over time. Be sure to update with the output of `s3cmd ls` as stated above!
 {{< /callout >}}
 
 ```yaml
-kernel: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64'
-initrd: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img'
+kernel: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-611.24.1.el9_7.x86_64'
+initrd: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-611.24.1.el9_7.x86_64.img'
 params: 'nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init'
 macs:
   - 52:54:00:be:ef:01
@@ -2417,8 +2417,8 @@ The output should be akin to:
         pub_key_ecdsa: ""
         pub_key_rsa: ""
     user-data: null
-  initrd: http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img
-  kernel: http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64
+  initrd: http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-611.24.1.el9_7.x86_64.img
+  kernel: http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-611.24.1.el9_7.x86_64
   macs:
     - 52:54:00:be:ef:01
     - 52:54:00:be:ef:02
@@ -2457,8 +2457,8 @@ be the same values from section 2.5.2.a but in JSON.
     "52:54:00:be:ef:05"
   ],
   "params": "nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init",
-  "kernel": "http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64",
-  "initrd": "http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img",
+  "kernel": "http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-611.24.1.el9_7.x86_64",
+  "initrd": "http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-611.24.1.el9_7.x86_64.img",
 
 }
 ```
@@ -2588,8 +2588,8 @@ Configuring (net0 52:54:00:be:ef:01)...... ok
 tftp://172.16.0.254:69/config.ipxe... ok
 Booting from http://172.16.0.254:8081/boot/v1/bootscript?mac=52:54:00:be:ef:01
 http://172.16.0.254:8081/boot/v1/bootscript... ok
-http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64... ok
-http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img... ok
+http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-611.24.1.el9_7.x86_64... ok
+http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-611.24.1.el9_7.x86_64.img... ok
 ```
 
 During Linux boot, output should indicate that the SquashFS image gets downloaded and loaded.
@@ -2958,8 +2958,8 @@ They should match the file above:
         pub_key_ecdsa: ""
         pub_key_rsa: ""
     user-data: null
-  initrd: http://172.16.0.254:7070/boot-images/efi-images/compute/base/initramfs-5.14.0-570.26.1.el9_6.x86_64.img
-  kernel: http://172.16.0.254:7070/boot-images/efi-images/compute/base/vmlinuz-5.14.0-570.26.1.el9_6.x86_64
+  initrd: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-611.24.1.el9_7.x86_64.img'
+  kernel: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-611.24.1.el9_7.x86_64'
   macs:
     - 52:54:00:be:ef:01
     - 52:54:00:be:ef:02
@@ -3036,8 +3036,8 @@ Configuring (net0 52:54:00:be:ef:01)...... ok
 tftp://172.16.0.254:69/config.ipxe... ok
 Booting from http://172.16.0.254:8081/boot/v1/bootscript?mac=52:54:00:be:ef:01
 http://172.16.0.254:8081/boot/v1/bootscript... ok
-http://172.16.0.254:7070/boot-images/efi-images/compute/base/vmlinuz-5.14.0-570.26.1.el9_6.x86_64... ok
-http://172.16.0.254:7070/boot-images/efi-images/compute/base/initramfs-5.14.0-570.26.1.el9_6.x86_64.img... ok
+http://172.16.0.254:7070/boot-images/efi-images/compute/base/vmlinuz-5.14.0-611.24.1.el9_7.x86_64... ok
+http://172.16.0.254:7070/boot-images/efi-images/compute/base/initramfs-5.14.0-611.24.1.el9_7.x86_64.img... ok
 ```
 
 {{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -1666,8 +1666,8 @@ Apply the policy in S3:
 
 ```bash
 s3cmd setpolicy /opt/workdir/s3-public-read-boot.json s3://boot-images \
-    --host=172.16.0.254:7070 \
-    --host-bucket=172.16.0.254:7070
+    --host=demo.openchami.cluster:7070 \
+    --host-bucket=demo.openchami.cluster:7070
 ```
 
 The output should be:
@@ -2074,12 +2074,12 @@ options:
   publish_tags:
     - 'rocky9'
   pkg_manager: dnf
-  parent: '172.16.0.254:5000/demo/compute-base:rocky9'
+  parent: 'demo.openchami.cluster:5000/demo/compute-base:rocky9'
   registry_opts_pull:
     - '--tls-verify=false'
 
   # Publish to local S3
-  publish_s3: 'http://172.16.0.254:7070'
+  publish_s3: 'http://demo.openchami.cluster:7070'
   s3_prefix: 'compute/debug/'
   s3_bucket: 'boot-images'
 
@@ -2096,15 +2096,15 @@ The debug image uses a few different directives that are worth drawing attention
 
   ```yaml
   name: 'compute-debug'
-  parent: '172.16.0.254:5000/demo/compute-base:rocky9'
+  parent: 'demo.openchami.cluster:5000/demo/compute-base:rocky9'
   registry_opts_pull:
     - '--tls-verify=false'
   ```
 
-- Push the image to `http://172.16.0.254:7070/boot-images/compute/debug/` in S3:
+- Push the image to `http://demo.openchami.cluster:7070/boot-images/compute/debug/` in S3:
 
   ```yaml
-  publish_s3: 'http://172.16.0.254:7070'
+  publish_s3: 'http://demo.openchami.cluster:7070'
   s3_prefix: 'compute/debug/'
   s3_bucket: 'boot-images'
   ```
@@ -2175,7 +2175,7 @@ For the debug boot artifacts, the URLs (everthing after `s3://`) for the
 print the actual URLs:
 
 ```bash
-s3cmd ls -Hr s3://boot-images | grep compute/debug | awk '{print $4}' | sed 's-s3://-http://172.16.0.254:7070/-'
+s3cmd ls -Hr s3://boot-images | grep compute/debug | awk '{print $4}' | sed 's-s3://-http://demo.openchami.cluster:7070/-'
 ```
 
 In a following section, these will be programmatically used to set boot

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -1915,7 +1915,7 @@ options:
     - '--tls-verify=false'
 
   # Publish SquashFS image to local S3
-  publish_s3: 'http://demo.openchami.cluster:9000'
+  publish_s3: 'http://demo.openchami.cluster:7070'
   s3_prefix: 'compute/base/'
   s3_bucket: 'boot-images'
 
@@ -2061,7 +2061,7 @@ options:
     - '--tls-verify=false'
 
   # Publish to local S3
-  publish_s3: 'http://172.16.0.254:9000'
+  publish_s3: 'http://172.16.0.254:7070'
   s3_prefix: 'compute/debug/'
   s3_bucket: 'boot-images'
 
@@ -2083,10 +2083,10 @@ The debug image uses a few different directives that are worth drawing attention
     - '--tls-verify=false'
   ```
 
-- Push the image to `http://172.16.0.254:9000/boot-images/compute/debug/` in S3:
+- Push the image to `http://172.16.0.254:7070/boot-images/compute/debug/` in S3:
 
   ```yaml
-  publish_s3: 'http://172.16.0.254:9000'
+  publish_s3: 'http://172.16.0.254:7070'
   s3_prefix: 'compute/debug/'
   s3_bucket: 'boot-images'
   ```
@@ -2157,7 +2157,7 @@ For the debug boot artifacts, the URLs (everthing after `s3://`) for the
 print the actual URLs:
 
 ```bash
-s3cmd ls -Hr s3://boot-images | grep compute/debug | awk '{print $4}' | sed 's-s3://-http://172.16.0.254:9000/-'
+s3cmd ls -Hr s3://boot-images | grep compute/debug | awk '{print $4}' | sed 's-s3://-http://172.16.0.254:7070/-'
 ```
 
 In a following section, these will be programmatically used to set boot
@@ -2297,7 +2297,7 @@ Then, create the payload for BSS,
 URIs for the boot artifacts:
 
 ```bash
-URIS=$(s3cmd ls -Hr s3://boot-images | grep compute/debug | awk '{print $4}' | sed 's-s3://-http://172.16.0.254:9000/-' | xargs)
+URIS=$(s3cmd ls -Hr s3://boot-images | grep compute/debug | awk '{print $4}' | sed 's-s3://-http://172.16.0.254:7070/-' | xargs)
 URI_IMG=$(echo "$URIS" | cut -d' ' -f1)
 URI_INITRAMFS=$(echo "$URIS" | cut -d' ' -f2)
 URI_KERNEL=$(echo "$URIS" | cut -d' ' -f3)
@@ -2323,9 +2323,9 @@ over time. Be sure to update with the output of `s3cmd ls` as stated above!
 {{< /callout >}}
 
 ```yaml
-kernel: 'http://172.16.0.254:9000/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64'
-initrd: 'http://172.16.0.254:9000/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img'
-params: 'nomodeset ro root=live:http://172.16.0.254:9000/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init'
+kernel: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64'
+initrd: 'http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img'
+params: 'nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init'
 macs:
   - 52:54:00:be:ef:01
   - 52:54:00:be:ef:02
@@ -2367,15 +2367,15 @@ The output should be akin to:
         pub_key_ecdsa: ""
         pub_key_rsa: ""
     user-data: null
-  initrd: http://172.16.0.254:9000/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img
-  kernel: http://172.16.0.254:9000/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64
+  initrd: http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img
+  kernel: http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64
   macs:
     - 52:54:00:be:ef:01
     - 52:54:00:be:ef:02
     - 52:54:00:be:ef:03
     - 52:54:00:be:ef:04
     - 52:54:00:be:ef:05
-  params: nomodeset ro root=live:http://172.16.0.254:9000/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init
+  params: nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init
 ```
 
 The things to check are:
@@ -2406,9 +2406,9 @@ be the same values from section 2.5.2.a but in JSON.
     "52:54:00:be:ef:04",
     "52:54:00:be:ef:05"
   ],
-  "params": "nomodeset ro root=live:http://172.16.0.254:9000/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init",
-  "kernel": "http://172.16.0.254:9000/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64",
-  "initrd": "http://172.16.0.254:9000/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img",
+  "params": "nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/debug/rocky9.6-compute-debug-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init",
+  "kernel": "http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64",
+  "initrd": "http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img",
 
 }
 ```
@@ -2538,8 +2538,8 @@ Configuring (net0 52:54:00:be:ef:01)...... ok
 tftp://172.16.0.254:69/config.ipxe... ok
 Booting from http://172.16.0.254:8081/boot/v1/bootscript?mac=52:54:00:be:ef:01
 http://172.16.0.254:8081/boot/v1/bootscript... ok
-http://172.16.0.254:9000/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64... ok
-http://172.16.0.254:9000/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img... ok
+http://172.16.0.254:7070/boot-images/efi-images/compute/debug/vmlinuz-5.14.0-570.26.1.el9_6.x86_64... ok
+http://172.16.0.254:7070/boot-images/efi-images/compute/debug/initramfs-5.14.0-570.26.1.el9_6.x86_64.img... ok
 ```
 
 During Linux boot, output should indicate that the SquashFS image gets downloaded and loaded.
@@ -2862,7 +2862,7 @@ Create `boot-compute-rocky9.yaml` with these values, using the same method used
 before to create the debug boot parameters.
 
 ```bash
-URIS=$(s3cmd ls -Hr s3://boot-images | grep compute/base | awk '{print $4}' | sed 's-s3://-http://172.16.0.254:9000/-' | xargs)
+URIS=$(s3cmd ls -Hr s3://boot-images | grep compute/base | awk '{print $4}' | sed 's-s3://-http://172.16.0.254:7070/-' | xargs)
 URI_IMG=$(echo "$URIS" | cut -d' ' -f1)
 URI_INITRAMFS=$(echo "$URIS" | cut -d' ' -f2)
 URI_KERNEL=$(echo "$URIS" | cut -d' ' -f3)
@@ -2908,15 +2908,15 @@ They should match the file above:
         pub_key_ecdsa: ""
         pub_key_rsa: ""
     user-data: null
-  initrd: http://172.16.0.254:9000/boot-images/efi-images/compute/base/initramfs-5.14.0-570.26.1.el9_6.x86_64.img
-  kernel: http://172.16.0.254:9000/boot-images/efi-images/compute/base/vmlinuz-5.14.0-570.26.1.el9_6.x86_64
+  initrd: http://172.16.0.254:7070/boot-images/efi-images/compute/base/initramfs-5.14.0-570.26.1.el9_6.x86_64.img
+  kernel: http://172.16.0.254:7070/boot-images/efi-images/compute/base/vmlinuz-5.14.0-570.26.1.el9_6.x86_64
   macs:
     - 52:54:00:be:ef:01
     - 52:54:00:be:ef:02
     - 52:54:00:be:ef:03
     - 52:54:00:be:ef:04
     - 52:54:00:be:ef:05
-  params: nomodeset ro root=live:http://172.16.0.254:9000/boot-images/compute/base/rocky9.6-compute-base-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init
+  params: nomodeset ro root=live:http://172.16.0.254:7070/boot-images/compute/base/rocky9.6-compute-base-rocky9 ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=ttyS0,115200 ip6=off cloud-init=enabled ds=nocloud-net;s=http://172.16.0.254:8081/cloud-init
 ```
 
 #### 2.8.2 Booting the Compute Node
@@ -2986,8 +2986,8 @@ Configuring (net0 52:54:00:be:ef:01)...... ok
 tftp://172.16.0.254:69/config.ipxe... ok
 Booting from http://172.16.0.254:8081/boot/v1/bootscript?mac=52:54:00:be:ef:01
 http://172.16.0.254:8081/boot/v1/bootscript... ok
-http://172.16.0.254:9000/boot-images/efi-images/compute/base/vmlinuz-5.14.0-570.26.1.el9_6.x86_64... ok
-http://172.16.0.254:9000/boot-images/efi-images/compute/base/initramfs-5.14.0-570.26.1.el9_6.x86_64.img... ok
+http://172.16.0.254:7070/boot-images/efi-images/compute/base/vmlinuz-5.14.0-570.26.1.el9_6.x86_64... ok
+http://172.16.0.254:7070/boot-images/efi-images/compute/base/initramfs-5.14.0-570.26.1.el9_6.x86_64.img... ok
 ```
 
 {{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -699,7 +699,7 @@ Reload Systemd to update it with the new changes and then start the services:
 sudo systemctl daemon-reload
 sudo systemctl start registry.service
 
-# Enable and start secret generation (one-time)
+# Enable and start secret generation for authentication with versity gateway(one-time)
 sudo systemctl enable --now versitygw-gensecrets.service
 
 # Start the versity gateway (generated from Quadlet - cannot be enabled directly)

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -1981,8 +1981,10 @@ If you find yourself with the error "The AWS Access Key Id you provided does
 not exist in our records.", determine whether values have been set for
 environment variables `ROOT_ACCESS_KEY` and `ROOT_SECRET_KEY` by observing the
 output of `env | grep KEY`. If no definitions exist for these variables, re-run
-the following command to pull them back in: `source <(sudo cat
-/etc/versitygw/secrets.env)`.
+the following command to pull them back in:
+```bash
+source <(sudo cat /etc/versitygw/secrets.env)
+```
 {{< /callout >}}
 
 This won't take as long as the base image since the only thing being done is

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -893,14 +893,17 @@ EOF
 This will allow the resolution of node hostnames, e.g. `de01.openchami.cluster`.
 
 {{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
+**If running an existing DNS server, be aware of potential port conflicts for
 port 53!** Although CoreDNS cannot bind to in-use IP/port combinations, it may
-be configured to forward queries to the existing DNS server instead. If you
-encounter a port conflict, CoreDNS is not a required service dependency and can
-be safely disabled; however, doing so means name resolution for nodes/BMCs will
-not function and you will need to manage node hostnames manually. A
-lower-friction alternative that preserves DNS functionality is to change the
-CoreDNS configuration to use an unused port like `1053` and manually specify
-that port to any DNS dependent CLI tools.
+be configured to forward queries to the existing DNS server instead (see the
+CoreDNS [`forward`](https://coredns.io/plugins/forward/) plugin).
+
+If you encounter a port conflict, CoreDNS is not a required service dependency
+and can be safely disabled; however, doing so means name resolution for
+nodes/BMCs will not function and you will need to manage node hostnames
+manually. A lower-friction alternative that preserves DNS functionality is to
+change the CoreDNS configuration to use an unused port like `1053` and manually
+specify that port to any DNS dependent CLI tools.
 {{< /callout >}}
 
 ### 1.5 Configure Cluster FQDN for Certificates

--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -845,7 +845,7 @@ Update the CoreDNS config as well:
 
 ```bash
 cat <<EOF | sudo tee /etc/openchami/configs/Corefile
-.:53 {
+.:1053 {
     # Enable readiness endpoint.
     ready
 
@@ -890,6 +890,14 @@ EOF
 ```
 
 This will allow the resolution of node hostnames, e.g. `de01.openchami.cluster`.
+
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
+The default `Corefile` provided with the installation serves primarily as a
+template and without these changes, the `coredns` service will fail to start. In
+summary, above we reconfigure the port assignment to avoid conflicts with
+`dnsmasq` and `aardvark` while also ensuring an endpoint has been configured for
+`smd_url`.
+{{< /callout >}}
 
 ### 1.5 Configure Cluster FQDN for Certificates
 


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [ ] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [ ] **REUSE Compliance**:  
  - [ ] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description

This is a port of PR https://github.com/OpenCHAMI/tutorial-2025/pull/12 which targeted: https://github.com/OpenCHAMI/tutorial-2025/issues/11

Below is a modified variant of the description listed in the original PR.

The primary purpose of this PR is to switch the **tutorial** from `minio` to `versitygw` as the former is terminating support for open-source. To this end, the existing [openchami quadlet for `versitygw`](https://github.com/OpenCHAMI/versitygw-quadlet) was introduced. Some additional updates were introduced and are listed below:
- adds instructions for `coredns` `Corefile` to address port conflicts with `dnsmasq` and `aardvark`
- adds `aws` CLI to address `s3cmd` XML schema incompatibilities for `setacl`
- ensures all relevant shell output blocks are up to date w.r.t the latest openchami releases at the time of writing 


### Type of Change

- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [x] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
