### PR TITLE
Add weekly digests for April and May 2026, archive layout, and JSON-LD support

### DIFF
--- a/content/news/weekly/2026-01-05.md
+++ b/content/news/weekly/2026-01-05.md
@@ -1,0 +1,46 @@
+---
+title: "OpenCHAMI Weekly Digest: Dec 29, 2025–Jan 05, 2026"
+date: "2026-01-05T09:00:00"
+slug: "weekly-digest-2026-01-05"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A quiet holiday-week digest — most maintainers were away. Activity picks back up next week.
+
+## Highlights
+
+- **Network-config endpoint lands in metadata-service:** [`metadata-service` PR #2](https://github.com/OpenCHAMI/metadata-service/pull/2) implements the v1 `/network-config` endpoint and enriches metadata with network interface details, an early step toward fuller cloud-init payload coverage from SMD.
+- **Weekly digest automation merged:** The [community repo's weekly digest workflow](https://github.com/OpenCHAMI/community/pull/38) was completed, providing the automation that powers these posts going forward.
+
+## New & Notable PRs
+
+- [Implement /network-config v1 endpoint (metadata-service #2)](https://github.com/OpenCHAMI/metadata-service/pull/2) by alexlovelltroy
+
+## Issues to Watch
+
+No new issues opened during the holiday window.
+
+## Releases
+
+No releases this week.
+
+## Contributor Thanks
+
+Thanks to **alexlovelltroy** for keeping the lights on through the holiday week and shipping the metadata-service network-config endpoint.
+
+---
+
+## What’s next?
+
+- Expect normal contribution cadence to resume as maintainers return from holiday.
+- Watch metadata-service for further cloud-init payload work building on `/network-config`.
+- The weekly digest workflow will begin auto-posting from here forward.
+
+## Proposed Blog Titles
+
+1. "Inside OpenCHAMI’s `/network-config` Endpoint: What v1 Brings"
+2. "Behind the Scenes: Automating the OpenCHAMI Weekly Digest"
+3. "Closing Out 2025: A Quick Look Back Before a Busy 2026"

--- a/content/news/weekly/2026-01-26.md
+++ b/content/news/weekly/2026-01-26.md
@@ -1,0 +1,62 @@
+---
+title: "OpenCHAMI Weekly Digest: Jan 19–Jan 26, 2026"
+date: "2026-01-26T09:00:00"
+slug: "weekly-digest-2026-01-26"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A focused week dominated by ARM cross-compilation fixes in `power-control`, HTTP-client and Redfish improvements in `smd`, and forward motion on the 2026 Developer Summit.
+
+## Highlights
+
+- **ARM cross-compilation gets sorted in power-control:** A run of merged PRs — [`power-control` #62](https://github.com/OpenCHAMI/power-control/pull/62) (migrate to latest SMD), [#63](https://github.com/OpenCHAMI/power-control/pull/63), [#64](https://github.com/OpenCHAMI/power-control/pull/64), [#65](https://github.com/OpenCHAMI/power-control/pull/65) — fix ARM cross-build and set `CGO_ENABLED=1` correctly. A parallel [`github-actions` PR #6](https://github.com/OpenCHAMI/github-actions/pull/6) addresses the same setting in the shared workflow templates.
+- **Custom HTTP clients for SMD service reservations:** [`smd` PR #83](https://github.com/OpenCHAMI/smd/pull/83) lands the ability to plug in a custom HTTP client when making `ServiceReservation` calls — opening the door to OAuth2-aware reservations, which [`power-control` PR #61](https://github.com/OpenCHAMI/power-control/pull/61) is already taking advantage of.
+- **SerialConsole and CommandShell in SMD:** [`smd` PR #81](https://github.com/OpenCHAMI/smd/pull/81) adds Redfish `SerialConsole` and `CommandShell` resource handling — a long-running PR that finally merged this week.
+- **Scope handling fix in power-control:** [`power-control` PR #60](https://github.com/OpenCHAMI/power-control/pull/60) corrects OAuth2 scope handling, improving the reliability of authenticated calls.
+- **Discovery tutorial updated to v0.6.0:** [`openchami.org` PR #68](https://github.com/OpenCHAMI/openchami.org/pull/68) refreshes the discovery tutorial to match `ochami` v0.6.0 conventions.
+- **Developer Summit 2026 announced:** [`openchami.org` PR #65](https://github.com/OpenCHAMI/openchami.org/pull/65) adds details for the OpenCHAMI Developer Summit @ UCL 2026 — mark your calendars.
+- **Two SMD releases this week:** [`smd` v2.19.1](https://github.com/OpenCHAMI/smd/releases/tag/v2.19.1) and [`smd` v2.19.2](https://github.com/OpenCHAMI/smd/releases/tag/v2.19.2) ship the HTTP-client and Redfish work.
+- **power-control v2.12.0 released:** [`power-control` v2.12.0](https://github.com/OpenCHAMI/power-control/releases/tag/v2.12.0) bundles the ARM-build and scope-handling fixes.
+
+## New & Notable PRs
+
+- [Allow custom HTTP client with ServiceReservation (smd #83)](https://github.com/OpenCHAMI/smd/pull/83) by cjh1
+- [Add SerialConsole and CommandShell to Redfish (smd #81)](https://github.com/OpenCHAMI/smd/pull/81) by cjh1
+- [Migrate power-control to latest SMD (power-control #62)](https://github.com/OpenCHAMI/power-control/pull/62) by cjh1
+- [Fix scope handling (power-control #60)](https://github.com/OpenCHAMI/power-control/pull/60) by cjh1
+- [Developer Summit @ UCL 2026 details (openchami.org #65)](https://github.com/OpenCHAMI/openchami.org/pull/65) by alexlovelltroy
+- [Discovery tutorial → ochami v0.6.0 (openchami.org #68)](https://github.com/OpenCHAMI/openchami.org/pull/68) by synackd
+
+## Issues to Watch
+
+No new issues opened in this window; the week's work was PR-driven.
+
+## Releases
+
+- [smd v2.19.2](https://github.com/OpenCHAMI/smd/releases/tag/v2.19.2)
+- [smd v2.19.1](https://github.com/OpenCHAMI/smd/releases/tag/v2.19.1)
+- [power-control v2.12.0](https://github.com/OpenCHAMI/power-control/releases/tag/v2.12.0)
+
+## Contributor Thanks
+
+- **cjh1** — dominated the week with the power-control ARM-build fix series plus the SMD HTTP-client and Redfish work.
+- **synackd** — kept the discovery tutorial current with the v0.6.0 ochami release.
+- **alexlovelltroy** — got the 2026 Developer Summit on the calendar publicly.
+
+---
+
+## What’s next?
+
+- Pick up the open [`power-control` PR #61](https://github.com/OpenCHAMI/power-control/pull/61) for OAuth2-enabled HTTP clients on reservation calls.
+- Resolve the [`github-actions` PR #6](https://github.com/OpenCHAMI/github-actions/pull/6) for shared `CGO_ENABLED` config to prevent the bug recurring elsewhere.
+- Continue cross-platform CI improvements as ARM rolls out across more components.
+
+## Proposed Blog Titles
+
+1. "ARM Cross-Compilation in OpenCHAMI: A power-control Case Study"
+2. "OAuth2 All the Way Down: Custom HTTP Clients for SMD ServiceReservations"
+3. "Redfish SerialConsole and CommandShell: What Lands in SMD v2.19"
+4. "Save the Date: OpenCHAMI Developer Summit @ UCL 2026"

--- a/content/news/weekly/2026-02-02.md
+++ b/content/news/weekly/2026-02-02.md
@@ -1,0 +1,51 @@
+---
+title: "OpenCHAMI Weekly Digest: Jan 26–Feb 02, 2026"
+date: "2026-02-02T09:00:00"
+slug: "weekly-digest-2026-02-02"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A quieter week focused on `image-builder` improvements and a notable new cloud-init feature request. The `openchami.org` repo also saw a bulk maintenance sweep across older digest and event PRs.
+
+## Highlights
+
+- **Image-builder runtime improvements:** [`image-builder` PR #54](https://github.com/OpenCHAMI/image-builder/pull/54) adds support for module operations when not building from scratch, and [PR #55](https://github.com/OpenCHAMI/image-builder/pull/55) removes ansible variable printing — both shipped by travisbcotton this week.
+- **User-provided repo config in image-builder:** [`image-builder` PR #53](https://github.com/OpenCHAMI/image-builder/pull/53) from smehta99 explores letting users supply their own repo config to the build pipeline. Closed for now; expect a follow-up.
+- **Multi-NIC cloud-init metadata proposed:** New issue [`cloud-init` #102](https://github.com/OpenCHAMI/cloud-init/issues/102) by Katakam-Rakesh asks SMD to expose multiple network interfaces in cloud-init metadata — useful for nodes with bonded or multi-fabric setups.
+
+## New & Notable PRs
+
+- [Module operations without scratch build (image-builder #54)](https://github.com/OpenCHAMI/image-builder/pull/54) by travisbcotton
+- [Remove ansible variable printing (image-builder #55)](https://github.com/OpenCHAMI/image-builder/pull/55) by travisbcotton
+- [User-provided repo config (image-builder #53)](https://github.com/OpenCHAMI/image-builder/pull/53) by smehta99
+
+## Issues to Watch
+
+- [Expose multiple network interfaces in cloud-init metadata (cloud-init #102)](https://github.com/OpenCHAMI/cloud-init/issues/102) — a real ask from operators running multi-NIC nodes.
+
+## Releases
+
+No releases this week.
+
+## Contributor Thanks
+
+- **travisbcotton** — back-to-back image-builder improvements this week.
+- **smehta99** — pushing on image-builder config flexibility.
+- **Katakam-Rakesh** — surfacing the multi-NIC cloud-init gap.
+
+---
+
+## What’s next?
+
+- Decide the path forward for user-provided repo config in `image-builder` — close, redesign, or merge a follow-up?
+- Triage [`cloud-init` #102](https://github.com/OpenCHAMI/cloud-init/issues/102) and identify the SMD-side fields that need to surface.
+- Plan upcoming OpenCHAMI Developer Summit @ UCL 2026 logistics.
+
+## Proposed Blog Titles
+
+1. "Building Smarter Images: Recent image-builder Improvements"
+2. "Multi-NIC Node Support in cloud-init: What Operators Are Asking For"
+3. "How OpenCHAMI Maintains Configurable Build Pipelines"

--- a/content/news/weekly/2026-02-09.md
+++ b/content/news/weekly/2026-02-09.md
@@ -1,0 +1,61 @@
+---
+title: "OpenCHAMI Weekly Digest: Feb 02–Feb 09, 2026"
+date: "2026-02-09T09:00:00"
+slug: "weekly-digest-2026-02-09"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A solid week across `fabrica`, `metadata-service`, and `ochami` — including the first `ochami` v0.6.1 patch and a fresh `fabrica` v0.4.0 release that lines up with the kubebuilder-style versioning work.
+
+## Highlights
+
+- **fabrica v0.4.0 ships kubebuilder-style versioning:** [`fabrica` v0.4.0](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.0) is the first release to incorporate the kubebuilder-style versioning landed via [PR #27](https://github.com/OpenCHAMI/fabrica/pull/27). The shape of fabrica's resource API is now closer to Kubernetes conventions.
+- **metadata-service catches up to fabrica's pre-release:** [`metadata-service` PR #4](https://github.com/OpenCHAMI/metadata-service/pull/4) by alexlovelltroy upgrades to the new fabrica pre-release and addresses legacy compatibility — a coordinated bump across the two repos.
+- **Lowercase resources work cleanly in fabrica:** [`fabrica` PR #32](https://github.com/OpenCHAMI/fabrica/pull/32) from bmcdonald3 fixes a usability papercut: adding a lower-case resource now just works. Paired with [PR #33](https://github.com/OpenCHAMI/fabrica/pull/33) which corrects the example-4 documentation.
+- **ochami v0.6.1 with power-status display:** [`ochami` v0.6.1](https://github.com/OpenCHAMI/ochami/releases/tag/v0.6.1) lands [PR #58](https://github.com/OpenCHAMI/ochami/pull/58) — power status is now visible directly from the CLI.
+- **magellan documentation, log messages, and tests:** [`magellan` PR #126](https://github.com/OpenCHAMI/magellan/pull/126) from davidallendj bundles a wave of correctness improvements: bug fixes, clearer log output, updated docs, and new regression tests.
+- **Profile-based cloud-init metadata explored:** [`metadata-service` PR #3](https://github.com/OpenCHAMI/metadata-service/pull/3) experiments with a `profile` query parameter for cloud-init metadata handlers. Closed for now; pattern likely to resurface.
+- **JSON/YAML input for magellan collect:** New feature request [`magellan` #128](https://github.com/OpenCHAMI/magellan/issues/128) — let `collect` accept JSON or YAML input so it composes with other tooling.
+- **fabrica package generation feature closed:** [`fabrica` #26](https://github.com/OpenCHAMI/fabrica/issues/26) from jacobsalmela on generating api packages for existing modules resolved this week.
+
+## New & Notable PRs
+
+- [Upgrade for new fabrica pre-release (metadata-service #4)](https://github.com/OpenCHAMI/metadata-service/pull/4) by alexlovelltroy
+- [Lower-case resources work (fabrica #32)](https://github.com/OpenCHAMI/fabrica/pull/32) by bmcdonald3
+- [Fix example 4 docs (fabrica #33)](https://github.com/OpenCHAMI/fabrica/pull/33) by bmcdonald3
+- [Power status display (ochami #58)](https://github.com/OpenCHAMI/ochami/pull/58) by cjh1
+- [Bug fixes + better logs + regression tests (magellan #126)](https://github.com/OpenCHAMI/magellan/pull/126) by davidallendj
+
+## Issues to Watch
+
+- [Allow `collect` to take JSON or YAML as input (magellan #128)](https://github.com/OpenCHAMI/magellan/issues/128) — a small interoperability win waiting for an implementation.
+
+## Releases
+
+- [ochami v0.6.1](https://github.com/OpenCHAMI/ochami/releases/tag/v0.6.1) — power status display
+- [fabrica v0.4.0](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.0) — kubebuilder-style versioning
+
+## Contributor Thanks
+
+- **alexlovelltroy** — coordinated the fabrica + metadata-service version bump.
+- **bmcdonald3** — the fabrica DX fixes (lowercase resources, example docs) make the framework friendlier.
+- **cjh1** — power status in the CLI lands in v0.6.1.
+- **davidallendj** — magellan correctness sweep with regression coverage.
+
+---
+
+## What’s next?
+
+- Pick up [`magellan` #128](https://github.com/OpenCHAMI/magellan/issues/128) to round out tooling interop.
+- Watch for follow-up fabrica releases that fully shake out the kubebuilder transition.
+- Continue propagating the fabrica v0.4 patterns into downstream services beyond metadata-service.
+
+## Proposed Blog Titles
+
+1. "Kubebuilder-Style Versioning Comes to fabrica v0.4.0"
+2. "ochami v0.6.1 Brings Power Status to Your Terminal"
+3. "Inside magellan's Recent Quality Sweep: Logs, Tests, and Docs"
+4. "Coordinated Releases: How metadata-service Catches Up With fabrica"

--- a/content/news/weekly/2026-03-09.md
+++ b/content/news/weekly/2026-03-09.md
@@ -1,0 +1,62 @@
+---
+title: "OpenCHAMI Weekly Digest: Mar 02–Mar 09, 2026"
+date: "2026-03-09T09:00:00"
+slug: "weekly-digest-2026-03-09"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A busy week with significant `inventory-service` foundational work, `fru-tracker` polish, and a fresh `ochami` v0.7.0 release.
+
+## Highlights
+
+- **ochami v0.7.0 released:** [`ochami` v0.7.0](https://github.com/OpenCHAMI/ochami/releases/tag/v0.7.0) ships this week, building on the v0.6.x line.
+- **inventory-service foundational work:** shunr-hpe lands a batch of PRs setting up the service: a [Debian-based Dockerfile](https://github.com/OpenCHAMI/inventory-service/pull/7), a [rename from `SmdV2` to `Csm` in function names](https://github.com/OpenCHAMI/inventory-service/pull/6), [REST tests for the remaining APIs](https://github.com/OpenCHAMI/inventory-service/pull/5), and an [extended Redfish endpoints post handler](https://github.com/OpenCHAMI/inventory-service/pull/2). A solid base to build on.
+- **fru-tracker polish:** bmcdonald3 ships five fru-tracker PRs this week — a [collector demo and tutorial](https://github.com/OpenCHAMI/fru-tracker/pull/11), [new-field support](https://github.com/OpenCHAMI/fru-tracker/pull/12), [intent reword for clarity](https://github.com/OpenCHAMI/fru-tracker/pull/13), [import fixes](https://github.com/OpenCHAMI/fru-tracker/pull/10), and the [collector code into demo dir](https://github.com/OpenCHAMI/fru-tracker/pull/9).
+- **Configurable hostname policy lands in coresmd:** [`coresmd` PR #47](https://github.com/OpenCHAMI/coresmd/pull/47) from davidallendj implements the configurable-hostname-policy feature for DHCPv4, addressing the long-running [`coresmd` #46](https://github.com/OpenCHAMI/coresmd/issues/46) discussion.
+- **ochami README + Makefile refresh:** [`ochami` PR #71](https://github.com/OpenCHAMI/ochami/pull/71) from synackd cleans up the README and Makefile — a quality-of-life win for new contributors.
+- **kube-deploy updates:** rainest landed [PR #7](https://github.com/OpenCHAMI/kube-deploy/pull/7) updating the demo workflow, while cjh1's [#4](https://github.com/OpenCHAMI/kube-deploy/pull/4) (argocd repo add) and [#5](https://github.com/OpenCHAMI/kube-deploy/pull/5) (ochami config path) tightened the deploy story.
+- **Cabinet discovery in ex-bootstrap:** new PR [`ex-bootstrap` #4](https://github.com/OpenCHAMI/ex-bootstrap/pull/4) from PowellTravis adds cabinet discovery and configuration.
+
+## New & Notable PRs
+
+- [Configurable Hostname Policy for DHCPv4 (coresmd #47)](https://github.com/OpenCHAMI/coresmd/pull/47) by davidallendj
+- [Debian-based Dockerfile (inventory-service #7)](https://github.com/OpenCHAMI/inventory-service/pull/7) by shunr-hpe
+- [REST tests for remaining APIs (inventory-service #5)](https://github.com/OpenCHAMI/inventory-service/pull/5) by shunr-hpe
+- [README and Makefile cleanup (ochami #71)](https://github.com/OpenCHAMI/ochami/pull/71) by synackd
+- [Tutorial/demo for the go collector (fru-tracker #11)](https://github.com/OpenCHAMI/fru-tracker/pull/11) by bmcdonald3
+- [Cabinet discovery and configuration (ex-bootstrap #4)](https://github.com/OpenCHAMI/ex-bootstrap/pull/4) by PowellTravis
+
+## Issues to Watch
+
+- [Omnibus things to fix for HSPF (kube-deploy #6)](https://github.com/OpenCHAMI/kube-deploy/issues/6) — rainest's running list of HSPF cleanup items.
+
+## Releases
+
+- [ochami v0.7.0](https://github.com/OpenCHAMI/ochami/releases/tag/v0.7.0)
+
+## Contributor Thanks
+
+- **shunr-hpe** — five inventory-service PRs this week setting the stage for the service.
+- **bmcdonald3** — fru-tracker quality and demo improvements.
+- **synackd** — ochami DX improvements.
+- **davidallendj** — DHCPv4 hostname policy in coresmd, closing a long-standing issue.
+- **cjh1, rainest** — kube-deploy work.
+- **PowellTravis** — kicking off cabinet discovery in ex-bootstrap.
+
+---
+
+## What’s next?
+
+- Land [`ex-bootstrap` PR #4](https://github.com/OpenCHAMI/ex-bootstrap/pull/4) and continue the cabinet-discovery thread.
+- Pick up the [`kube-deploy` omnibus](https://github.com/OpenCHAMI/kube-deploy/issues/6) and start chipping at it.
+- Continue inventory-service hardening on the foundations shunr-hpe laid.
+
+## Proposed Blog Titles
+
+1. "From SmdV2 to Csm: How inventory-service Is Taking Shape"
+2. "Configurable Hostname Policy: Flexible DHCPv4 in coresmd"
+3. "Inside fru-tracker: The Go Collector and How to Extend It"
+4. "ochami v0.7.0: What's in This Release"

--- a/content/news/weekly/2026-03-16.md
+++ b/content/news/weekly/2026-03-16.md
@@ -1,0 +1,65 @@
+---
+title: "OpenCHAMI Weekly Digest: Mar 09–Mar 16, 2026"
+date: "2026-03-16T09:00:00"
+slug: "weekly-digest-2026-03-16"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A week dominated by **aarch64 support** across multiple components and a parallel **REUSE compliance** push. New `opaal` release, structured-logging proposal for `bss`, and documentation continues to accrete.
+
+## Highlights
+
+- **aarch64 support across opaal and local-ca:** A coordinated push closes [`opaal` #7](https://github.com/OpenCHAMI/opaal/issues/7) for aarch64 container images via [PR #8](https://github.com/OpenCHAMI/opaal/pull/8) and [PR #9](https://github.com/OpenCHAMI/opaal/pull/9) (Goreleaser env fix). `local-ca` v0.2.3 hit a [Dockerfile bug on arm64](https://github.com/OpenCHAMI/local-ca/issues/5) that synackd resolved in [PR #6](https://github.com/OpenCHAMI/local-ca/pull/6), plus [CI fixes for container builds](https://github.com/OpenCHAMI/local-ca/pull/4) and a related [unknown/unknown architecture report](https://github.com/OpenCHAMI/local-ca/issues/3).
+- **REUSE v3.3 compliance lands in coresmd:** [`coresmd` PR #48](https://github.com/OpenCHAMI/coresmd/pull/48) from synackd adds a Makefile, brings the repo into REUSE v3.3 compliance, and refreshes the README — a model worth replicating across the org.
+- **REUSE template year fix in fabrica:** [`fabrica` #35](https://github.com/OpenCHAMI/fabrica/issues/35) caught a hard-coded `2025` in the REUSE copyright template; [PR #36](https://github.com/OpenCHAMI/fabrica/pull/36) makes it dynamic.
+- **opaal v0.3.12 released:** [`opaal` v0.3.12](https://github.com/OpenCHAMI/opaal/releases/tag/v0.3.12) ships, and the `release` repo updates [opaal container references to v0.3.12](https://github.com/OpenCHAMI/release/pull/41).
+- **local-ca v0.2.4 cascade:** [`release` PR #44](https://github.com/OpenCHAMI/release/pull/44) bumps local-ca v0.2.2 → v0.2.4, which incorporates the arm64 fixes from above.
+- **coredhcp config comments support:** [`coresmd` PR #49](https://github.com/OpenCHAMI/coresmd/pull/49) adds support for comments in coredhcp configs — a small but real DX win.
+- **Structured logging proposed for bss:** [`bss` #77](https://github.com/OpenCHAMI/bss/issues/77) from seantronsen proposes moving bss to structured logging — a foundation for downstream log aggregation (Vector, Loki, etc.).
+- **Slurm install docs:** [`openchami.org` PR #72](https://github.com/OpenCHAMI/openchami.org/pull/72) from lunamorrow lands; a follow-up [PR #83](https://github.com/OpenCHAMI/openchami.org/pull/83) was closed but the documentation is in.
+- **FRU tracker blog post + tutorial reorg:** [`openchami.org` #77](https://github.com/OpenCHAMI/openchami.org/pull/77) (FRU tracker blog by bmcdonald3) and [#71](https://github.com/OpenCHAMI/openchami.org/pull/71) (tutorial section reorganization by davidallendj) landed.
+
+## New & Notable PRs
+
+- [REUSE v3.3 + Makefile (coresmd #48)](https://github.com/OpenCHAMI/coresmd/pull/48) by synackd
+- [arm64/aarch64 build support (opaal #8)](https://github.com/OpenCHAMI/opaal/pull/8) by davidallendj
+- [Dockerfile fix for arm64 (local-ca #6)](https://github.com/OpenCHAMI/local-ca/pull/6) by synackd
+- [coredhcp config comments (coresmd #49)](https://github.com/OpenCHAMI/coresmd/pull/49) by synackd
+- [Install Slurm docs (openchami.org #72)](https://github.com/OpenCHAMI/openchami.org/pull/72) by lunamorrow
+- [FRU tracker blog post (openchami.org #77)](https://github.com/OpenCHAMI/openchami.org/pull/77) by bmcdonald3
+
+## Issues to Watch
+
+- [Switch to structured logging (bss #77)](https://github.com/OpenCHAMI/bss/issues/77) — foundational for observability work.
+- [aarch64 support (opaal #10)](https://github.com/OpenCHAMI/opaal/issues/10) — sibling of #7; ongoing.
+
+## Releases
+
+- [opaal v0.3.12](https://github.com/OpenCHAMI/opaal/releases/tag/v0.3.12)
+
+## Contributor Thanks
+
+- **synackd** — leading the REUSE + arm64 + DX cleanup work across coresmd, fabrica, local-ca, and opaal.
+- **davidallendj** — opaal arm64 build, plus opaal release work and tutorial reorganization.
+- **middelkoopt** — surfacing real arm64 bugs in opaal and local-ca.
+- **lunamorrow** — Slurm installation documentation.
+- **bmcdonald3** — FRU tracker blog post and ongoing engagement.
+- **seantronsen** — structured-logging proposal for bss.
+
+---
+
+## What’s next?
+
+- Resolve the remaining [`opaal` aarch64 ticket #10](https://github.com/OpenCHAMI/opaal/issues/10) to close out the arm64 push.
+- Pick up [`bss` #77](https://github.com/OpenCHAMI/bss/issues/77) for structured logging — pairs naturally with the observability pipeline.
+- Roll the REUSE v3.3 + Makefile pattern from coresmd to other repos.
+
+## Proposed Blog Titles
+
+1. "OpenCHAMI on aarch64: The Story Behind the Multi-Arch Push"
+2. "REUSE v3.3 in coresmd: A Template for the Rest of the Org"
+3. "Structured Logging in bss: Foundation for Observability"
+4. "Installing Slurm on OpenCHAMI: New Documentation Walkthrough"

--- a/content/news/weekly/2026-03-23.md
+++ b/content/news/weekly/2026-03-23.md
@@ -1,0 +1,66 @@
+---
+title: "OpenCHAMI Weekly Digest: Mar 16–Mar 23, 2026"
+date: "2026-03-23T09:00:00"
+slug: "weekly-digest-2026-03-23"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+The `remote-console` import from CSM lands and clears a stack of old issues, a `coresmd` refactor separates packages cleanly, and the OpenCHAMI Developer Summit @ UCL 2026 gets Cambridge day-0 details.
+
+## Highlights
+
+- **remote-console comes online:** [`remote-console` PR #15](https://github.com/OpenCHAMI/remote-console/pull/15) from cjh1 refactors internals and exposes a websocket interface — the merge clears a row of long-running import-from-CSM issues: [#1](https://github.com/OpenCHAMI/remote-console/issues/1) (import), [#2](https://github.com/OpenCHAMI/remote-console/issues/2) (configurable), [#3](https://github.com/OpenCHAMI/remote-console/issues/3) (integration tests), [#7](https://github.com/OpenCHAMI/remote-console/issues/7) (Mountain Node support), and [#8](https://github.com/OpenCHAMI/remote-console/issues/8) (node type configuration). A satisfying batch close.
+- **coresmd package separation:** [`coresmd` PR #51](https://github.com/OpenCHAMI/coresmd/pull/51) from synackd splits coredhcp/coresmd functionality into separate packages, paying down a long-standing architectural debt.
+- **`ochami console` command proposed:** [`ochami` #72](https://github.com/OpenCHAMI/ochami/issues/72) from cjh1 asks for an `ochami console` command — building on the remote-console work to make serial-console access first-class in the CLI.
+- **smd default DB port:** [`smd` PR #85](https://github.com/OpenCHAMI/smd/pull/85) from mattmix uses a sensible default DB port when none is specified — reducing config-error frustration.
+- **Cambridge day-0 event updates:** [`openchami.org` PR #85](https://github.com/OpenCHAMI/openchami.org/pull/85) from dominicfriend adds day-0 details for the UCL 2026 Summit. HPSFcon 2026 docs also tightened in [PR #87](https://github.com/OpenCHAMI/openchami.org/pull/87).
+- **Hugo deploy workflow updates:** [`openchami.org` PR #88](https://github.com/OpenCHAMI/openchami.org/pull/88) refreshes the Hugo deployment workflow.
+- **TRS library ARM issue resolved:** [`power-control` #53](https://github.com/OpenCHAMI/power-control/issues/53) — TRS library blocking ARM builds — closed. ARM story continues to improve.
+- **Signing-subkey expiration visible in release flow:** [`release` PR #47](https://github.com/OpenCHAMI/release/pull/47) from alexlovelltroy adds a step to display the signing subkey expiration — useful operational visibility.
+- **inventory-service plugins work:** [`inventory-service` PR #8](https://github.com/OpenCHAMI/inventory-service/pull/8) from shunr-hpe lands more on the plugins direction.
+- **coresmd-using-fabrica refactor proposed:** [`coresmd` #53](https://github.com/OpenCHAMI/coresmd/issues/53) from davidallendj suggests refactoring the coresmd plugin to use Fabrica-generated clients — a structural simplification once the work is sequenced.
+
+## New & Notable PRs
+
+- [Refactor internals + websocket interface (remote-console #15)](https://github.com/OpenCHAMI/remote-console/pull/15) by cjh1
+- [Separate coredhcp/coresmd packages (coresmd #51)](https://github.com/OpenCHAMI/coresmd/pull/51) by synackd
+- [Default DB port (smd #85)](https://github.com/OpenCHAMI/smd/pull/85) by mattmix
+- [Display signing subkey expiration (release #47)](https://github.com/OpenCHAMI/release/pull/47) by alexlovelltroy
+- [Cambridge day 0 event updates (openchami.org #85)](https://github.com/OpenCHAMI/openchami.org/pull/85) by dominicfriend
+- [Plugins alt (inventory-service #8)](https://github.com/OpenCHAMI/inventory-service/pull/8) by shunr-hpe
+
+## Issues to Watch
+
+- [Add `ochami console` command (ochami #72)](https://github.com/OpenCHAMI/ochami/issues/72) — pairs naturally with the remote-console websocket interface.
+- [Refactor plugin to use Fabrica generated clients (coresmd #53)](https://github.com/OpenCHAMI/coresmd/issues/53) — structural; worth scoping.
+- [Switch to structured logging (bss #77)](https://github.com/OpenCHAMI/bss/issues/77) — still open, still load-bearing for observability.
+
+## Releases
+
+No releases this week.
+
+## Contributor Thanks
+
+- **cjh1** — landed the remote-console import work that closed five old issues.
+- **synackd** — coresmd package separation, plus the HPSF docs fixes.
+- **mattmix** — smd default DB port quality-of-life win.
+- **shunr-hpe** — continuing the inventory-service work.
+- **dominicfriend** — Cambridge day-0 event content for the UCL 2026 Summit.
+- **evanmcc, rainest** — historical issues now closed thanks to the remote-console merge and TRS/ARM resolution.
+
+---
+
+## What’s next?
+
+- Build out `ochami console` against the new remote-console websocket interface.
+- Sequence the coresmd-uses-Fabrica refactor [#53](https://github.com/OpenCHAMI/coresmd/issues/53) so it composes with the recent package separation.
+- Push more aarch64 across remaining components.
+
+## Proposed Blog Titles
+
+1. "remote-console Comes to OpenCHAMI: Inside the CSM Import"
+2. "Cleaner coresmd: A Look at the Package-Separation Refactor"
+3. "Save the Day-0: What to Expect at the UCL 2026 Summit"

--- a/content/news/weekly/2026-03-30.md
+++ b/content/news/weekly/2026-03-30.md
@@ -1,0 +1,69 @@
+---
+title: "OpenCHAMI Weekly Digest: Mar 23–Mar 30, 2026"
+date: "2026-03-30T09:00:00"
+slug: "weekly-digest-2026-03-30"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A heavy week with four releases shipping, the flexible hostname-policy work in `coresmd` finishing up, and Dependabot starting to roll across the org.
+
+## Highlights
+
+- **Four releases in seven days:** [`smd` v2.19.3](https://github.com/OpenCHAMI/smd/releases/tag/v2.19.3), [`coresmd` v0.6.0](https://github.com/OpenCHAMI/coresmd/releases/tag/v0.6.0), [`ochami` v0.7.1](https://github.com/OpenCHAMI/ochami/releases/tag/v0.7.1), and a [`fru-tracker` pr-18 cut](https://github.com/OpenCHAMI/fru-tracker/releases/tag/pr-18). Steady cadence across the core stack.
+- **Flexible hostname policy closes out:** [`coresmd` PR #52](https://github.com/OpenCHAMI/coresmd/pull/52) from synackd implements the flexible hostname policy in coredhcp/coresmd — closing [coresmd #46](https://github.com/OpenCHAMI/coresmd/issues/46) (the original feature request) and informing follow-up [coresmd #57](https://github.com/OpenCHAMI/coresmd/issues/57) (id_set for rules) opened later in the week.
+- **Subnet-rich rules in coresmd:** [`coresmd` #56](https://github.com/OpenCHAMI/coresmd/issues/56) from travisbcotton — rich rules for per-subnet routers — proposed and closed in the same window. Quick turnaround.
+- **Dependabot starts landing PRs:** Multiple dep bumps merged across `coresmd`, `ochami`, and `deployment-recipes` (golang.org/x/crypto, grpc, coredns, helm-related actions). [`deployment-recipes` #143](https://github.com/OpenCHAMI/deployment-recipes/pull/143) (actions/checkout v4→v6) still pending — older bumps in the queue worth review.
+- **fru-tracker integration testing:** [`fru-tracker` PR #16](https://github.com/OpenCHAMI/fru-tracker/pull/16) adds integration tests; [PR #15](https://github.com/OpenCHAMI/fru-tracker/pull/15) switches parent-child linking to serialNumber from redfish_uri; [PR #17](https://github.com/OpenCHAMI/fru-tracker/pull/17) trims unused model fields. Continued bmcdonald3 momentum.
+- **local-ca gets arm64/v8 CI:** [`local-ca` PR #7](https://github.com/OpenCHAMI/local-ca/pull/7) from synackd adds `linux/arm64/v8` to CI, plus [PR #8](https://github.com/OpenCHAMI/local-ca/pull/8) fixes step-ca env var passing.
+- **tokensmith ursa policy loader v2 (round 2):** [`tokensmith` PR #9](https://github.com/OpenCHAMI/tokensmith/pull/9) from synackd lands the second take on the ursa policy loader work after the earlier revert.
+- **TSC agenda issue template:** [`community` PR #41](https://github.com/OpenCHAMI/community/pull/41) from slandath adds a TSC agenda item template — formalizing how items reach the [TSC Meeting Agenda](https://github.com/orgs/OpenCHAMI/projects/11) board.
+- **RHEL repo support proposed for image-builder:** [`image-builder` #32](https://github.com/OpenCHAMI/image-builder/issues/32) from treydock — long-standing ask for RHEL repos — got attention this week.
+- **Profile-based node configuration RFD:** [`roadmap` #121](https://github.com/OpenCHAMI/roadmap/issues/121) — alexlovelltroy's RFD on profile-based node config and an API shim — gained discussion.
+
+## New & Notable PRs
+
+- [Flexible hostname policy (coresmd #52)](https://github.com/OpenCHAMI/coresmd/pull/52) by synackd
+- [arm64/v8 CI for local-ca (local-ca #7)](https://github.com/OpenCHAMI/local-ca/pull/7) by synackd
+- [Ursa policy loader v2 part 2 (tokensmith #9)](https://github.com/OpenCHAMI/tokensmith/pull/9) by synackd
+- [Integration tests + model trim (fru-tracker #15, #16, #17)](https://github.com/OpenCHAMI/fru-tracker/pull/16) by bmcdonald3
+- [TSC agenda issue template (community #41)](https://github.com/OpenCHAMI/community/pull/41) by slandath
+- [GPG key reporting + key-to-sign env (release #45, #46)](https://github.com/OpenCHAMI/release/pull/45) by alexlovelltroy and synackd
+
+## Issues to Watch
+
+- [Implement `id_set` for CoreSMD rules (coresmd #57)](https://github.com/OpenCHAMI/coresmd/issues/57) — natural follow-on to hostname policy work.
+- [Documentation discrepancies (fabrica #40)](https://github.com/OpenCHAMI/fabrica/issues/40) — seantronsen flagging gaps as fabrica matures.
+- [RHEL repo support (image-builder #32)](https://github.com/OpenCHAMI/image-builder/issues/32) — long-standing community ask.
+
+## Releases
+
+- [smd v2.19.3](https://github.com/OpenCHAMI/smd/releases/tag/v2.19.3)
+- [coresmd v0.6.0](https://github.com/OpenCHAMI/coresmd/releases/tag/v0.6.0) — bundles the flexible hostname policy work
+- [ochami v0.7.1](https://github.com/OpenCHAMI/ochami/releases/tag/v0.7.1)
+- [fru-tracker pr-18](https://github.com/OpenCHAMI/fru-tracker/releases/tag/pr-18)
+
+## Contributor Thanks
+
+- **synackd** — biggest contributor week again: hostname policy in coresmd, arm64 CI in local-ca, tokensmith follow-up, plus release-pipeline GPG fixes.
+- **bmcdonald3** — three more fru-tracker PRs (integration tests, model cleanup, identity shift to serialNumber).
+- **alexlovelltroy** — release-pipeline GPG visibility + sustained RFD work.
+- **slandath** — TSC agenda template, formalizing the meeting-prep flow.
+- **travisbcotton, dominicfriend, green-br** — proposals and event content.
+
+---
+
+## What’s next?
+
+- Land [`coresmd` #57](https://github.com/OpenCHAMI/coresmd/issues/57) `id_set` rules on the hostname-policy foundation.
+- Triage the lingering Dependabot PRs in [`deployment-recipes`](https://github.com/OpenCHAMI/deployment-recipes/pulls); some have been open since November.
+- Move [`image-builder` #32](https://github.com/OpenCHAMI/image-builder/issues/32) RHEL repo support into a concrete plan.
+
+## Proposed Blog Titles
+
+1. "Flexible Hostname Policy Lands in coresmd v0.6.0"
+2. "Inside the OpenCHAMI Release Pipeline: Signing Visibility"
+3. "TSC Meeting Agendas: How Items Reach the Board"
+4. "Four Releases in a Week: A Snapshot of OpenCHAMI's Cadence"

--- a/content/news/weekly/2026-04-06.md
+++ b/content/news/weekly/2026-04-06.md
@@ -1,0 +1,71 @@
+---
+title: "OpenCHAMI Weekly Digest: Mar 30–Apr 06, 2026"
+date: "2026-04-06T09:00:00"
+slug: "weekly-digest-2026-04-06"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A *very* busy week — `tokensmith` ships its first three releases, `inventory-service` and `fabrica` integration deepens, and several long-running issues close.
+
+## Highlights
+
+- **tokensmith reaches its first releases:** Three tags this week — [`tokensmith` v0.0.1](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.0.1), [v0.0.2](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.0.2), and a jump to [v0.3.0](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.3.0). The big v0.3.0 release follows [PR #19](https://github.com/OpenCHAMI/tokensmith/pull/19) updating tokensmith for use with SMD and the new fabrica-based services.
+- **inventory-service catches up to fabrica HEAD:** shunr-hpe lands [`inventory-service` #10](https://github.com/OpenCHAMI/inventory-service/pull/10) (update to fabrica `442df75`), [#11](https://github.com/OpenCHAMI/inventory-service/pull/11) (drop the "alternate ID" naming), and [#12](https://github.com/OpenCHAMI/inventory-service/pull/12) (add CSM service REST endpoints). The service is taking shape fast.
+- **tokensmith hardening:** [`tokensmith` PR #13](https://github.com/OpenCHAMI/tokensmith/pull/13) (dockerfile runtime flags), [#14](https://github.com/OpenCHAMI/tokensmith/pull/14) (per-PR container builds), [#15](https://github.com/OpenCHAMI/tokensmith/pull/15) (JWKS format fix), [#17](https://github.com/OpenCHAMI/tokensmith/pull/17) (generate `kid` on key creation), and [#18](https://github.com/OpenCHAMI/tokensmith/pull/18) (skip publish on PR-only Goreleaser runs) — all landed this week. Plus [#11](https://github.com/OpenCHAMI/tokensmith/pull/11) (bootstrap token feature).
+- **fabrica gains module compatibility checks:** [`fabrica` PR #38](https://github.com/OpenCHAMI/fabrica/pull/38) from alexlovelltroy adds module compatibility checks and tests for code generation — protecting against generator/runtime drift.
+- **fabrica + tokensmith integration shipped:** [`fabrica` PR #34](https://github.com/OpenCHAMI/fabrica/pull/34) (tokensmith authn/authz feature) lands.
+- **coresmd v0.6.1 cleanup release:** [`coresmd` v0.6.1](https://github.com/OpenCHAMI/coresmd/releases/tag/v0.6.1) ships a follow-on to the v0.6.0 flexible hostname policy work.
+- **Magellan BMC configuration RFD:** new [`magellan` #129](https://github.com/OpenCHAMI/magellan/issues/129) from davidallendj proposes BMC configuration (NTP, syslog, SSH keys, etc.) via magellan — bringing more BMC lifecycle into scope.
+- **Old magellan issues clear:** [`magellan` #122](https://github.com/OpenCHAMI/magellan/issues/122) (manual pages), [#123](https://github.com/OpenCHAMI/magellan/issues/123) (cache default), [#127](https://github.com/OpenCHAMI/magellan/issues/127) (RF SerialConsole) all closed.
+- **`/swagger` → `/docs` resurfaces:** [`fabrica` #31](https://github.com/OpenCHAMI/fabrica/issues/31) — the rename from `/swagger` to `/docs` — got attention again as fabrica matures.
+
+## New & Notable PRs
+
+- [Update tokensmith for SMD + fabrica services (tokensmith #19)](https://github.com/OpenCHAMI/tokensmith/pull/19) by alexlovelltroy
+- [Module compatibility check for code generation (fabrica #38)](https://github.com/OpenCHAMI/fabrica/pull/38) by alexlovelltroy
+- [Tokensmith authn/authz feature (fabrica #34)](https://github.com/OpenCHAMI/fabrica/pull/34) by alexlovelltroy
+- [Add CSM service REST endpoints (inventory-service #12)](https://github.com/OpenCHAMI/inventory-service/pull/12) by shunr-hpe
+- [Update inventory-service to latest fabrica (inventory-service #10)](https://github.com/OpenCHAMI/inventory-service/pull/10) by shunr-hpe
+- [Bootstrap token (tokensmith #11)](https://github.com/OpenCHAMI/tokensmith/pull/11) by alexlovelltroy
+- [Fix JWKS format (tokensmith #15)](https://github.com/OpenCHAMI/tokensmith/pull/15) by travisbcotton
+
+## Issues to Watch
+
+- [BMC NTP/Syslog/SSH key config via magellan (magellan #129)](https://github.com/OpenCHAMI/magellan/issues/129) — expands magellan's scope from discovery to lifecycle.
+- [Add insecure token provider (tokensmith #12)](https://github.com/OpenCHAMI/tokensmith/issues/12) — dev-mode shortcut.
+- [Track service version (fabrica #41)](https://github.com/OpenCHAMI/fabrica/issues/41) — observability + compatibility.
+- [`id_set` for CoreSMD rules (coresmd #57)](https://github.com/OpenCHAMI/coresmd/issues/57) — still open from last week.
+- [Switch coresmd to structured logging (coresmd #50)](https://github.com/OpenCHAMI/coresmd/issues/50) — sibling of bss structured-logging proposal.
+
+## Releases
+
+- [tokensmith v0.3.0](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.3.0) — the headline release with SMD + fabrica support
+- [tokensmith v0.0.2](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.0.2)
+- [tokensmith v0.0.1](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.0.1)
+- [coresmd v0.6.1](https://github.com/OpenCHAMI/coresmd/releases/tag/v0.6.1)
+
+## Contributor Thanks
+
+- **alexlovelltroy** — drove the tokensmith + fabrica + coresmd integration arc this week.
+- **travisbcotton** — tokensmith hardening (JWKS, key kid, dockerfile, signing consistency).
+- **shunr-hpe** — sustained inventory-service progress.
+- **synackd** — tokensmith CI patterns + ongoing review presence.
+- **davidallendj** — BMC config RFD on magellan.
+
+---
+
+## What’s next?
+
+- Resolve the tokensmith v0.0.x → v0.3.0 jump in the release notes / changelog narrative.
+- Pick up `magellan #129` BMC configuration — design the surface before implementation.
+- Land `coresmd #57` (`id_set`) and start the structured-logging work in `coresmd #50` and `bss #77`.
+
+## Proposed Blog Titles
+
+1. "Introducing tokensmith v0.3.0: SMD-Compatible Service Auth"
+2. "fabrica + tokensmith: How OpenCHAMI Services Talk to Each Other"
+3. "inventory-service Comes of Age: CSM REST Endpoints"
+4. "Beyond Discovery: Configuring BMCs Through magellan"

--- a/content/news/weekly/2026-04-13.md
+++ b/content/news/weekly/2026-04-13.md
@@ -1,0 +1,61 @@
+---
+title: "OpenCHAMI Weekly Digest: Apr 06–Apr 13, 2026"
+date: "2026-04-13T09:00:00"
+slug: "weekly-digest-2026-04-13"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A focused week with `coresmd` gaining tokensmith-backed authentication, `inventory-service` adding a memberships API, and a new Flexible Hardware Identification RFD on the table.
+
+## Highlights
+
+- **TokenSmith-backed service auth for coresmd:** [`coresmd` PR #60](https://github.com/OpenCHAMI/coresmd/pull/60) from alexlovelltroy implements TokenSmith-backed authentication for the coresmd service — extending the auth pattern landed in fabrica last week into the coresmd plugin surface.
+- **Memberships REST API in inventory-service:** [`inventory-service` PR #13](https://github.com/OpenCHAMI/inventory-service/pull/13) from shunr-hpe adds the memberships REST endpoints — another step on the path to feature parity with the legacy SMD surfaces.
+- **SMD functional tests fixed:** [`smd` PR #87](https://github.com/OpenCHAMI/smd/pull/87) from shunr-hpe brings the functional tests back to passing — important groundwork for further smd changes to land safely.
+- **Improved tokensmith failure logging:** [`tokensmith` PR #21](https://github.com/OpenCHAMI/tokensmith/pull/21) from alexlovelltroy enhances logging for service-token authentication failures and adds a test for target-service mismatch. Important for diagnosing auth issues in the field.
+- **Flexible Hardware Identification RFD opened:** [`roadmap` #122](https://github.com/OpenCHAMI/roadmap/issues/122) from bmcdonald3 proposes a Flexible Hardware Identification and Hierarchy Linking model. Connects to the parent/child serial-number rework done in [fru-tracker #15](https://github.com/OpenCHAMI/fru-tracker/pull/15) earlier.
+- **fabrica Prometheus metrics in progress:** [`fabrica` PR #39](https://github.com/OpenCHAMI/fabrica/pull/39) from alexlovelltroy works on Prometheus metrics support — still open, but movement on the observability front.
+- **fabrica documentation cleanup:** [`fabrica` #42](https://github.com/OpenCHAMI/fabrica/issues/42) (broken/outdated tutorials, raised by seantronsen) closed this week.
+- **image-builder long-runners merged:** [`image-builder` PR #52](https://github.com/OpenCHAMI/image-builder/pull/52) (copy files earlier in build) and [#49](https://github.com/OpenCHAMI/image-builder/pull/49) (multi-arch support) — both originally from late 2025 — closed and worked through this week. [PR #56](https://github.com/OpenCHAMI/image-builder/pull/56) for write-able repo configs is now actively open.
+
+## New & Notable PRs
+
+- [TokenSmith-backed service auth (coresmd #60)](https://github.com/OpenCHAMI/coresmd/pull/60) by alexlovelltroy
+- [Memberships REST API (inventory-service #13)](https://github.com/OpenCHAMI/inventory-service/pull/13) by shunr-hpe
+- [Fix functional tests (smd #87)](https://github.com/OpenCHAMI/smd/pull/87) by shunr-hpe
+- [Token-failure logging + tests (tokensmith #21)](https://github.com/OpenCHAMI/tokensmith/pull/21) by alexlovelltroy
+- [Prometheus metrics (fabrica #39)](https://github.com/OpenCHAMI/fabrica/pull/39) by alexlovelltroy
+
+## Issues to Watch
+
+- [Flexible Hardware Identification and Hierarchy Linking (roadmap #122)](https://github.com/OpenCHAMI/roadmap/issues/122) — RFD; foundational for the hardware-graph story.
+- [BMC config via magellan (magellan #129)](https://github.com/OpenCHAMI/magellan/issues/129) — still open from last week.
+
+## Releases
+
+- [tokensmith v0.3.0](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.3.0) — first major tokensmith release with SMD + fabrica support (created last week; landed in this window).
+
+## Contributor Thanks
+
+- **alexlovelltroy** — pushed the auth thread through coresmd; opened the fabrica Prometheus PR.
+- **shunr-hpe** — kept inventory-service moving with memberships REST + smd functional-test fix.
+- **bmcdonald3** — flexible hardware identification RFD.
+- **seantronsen** — kept the doc-quality pressure on fabrica.
+
+---
+
+## What’s next?
+
+- Merge [`coresmd` #60](https://github.com/OpenCHAMI/coresmd/pull/60) once review settles; pairs with last week's tokensmith release.
+- Move [`fabrica` Prometheus metrics PR #39](https://github.com/OpenCHAMI/fabrica/pull/39) toward landing.
+- Get RFD discussion going on [`roadmap` #122](https://github.com/OpenCHAMI/roadmap/issues/122).
+
+## Proposed Blog Titles
+
+1. "TokenSmith Authentication Reaches coresmd: A Look at the Pattern"
+2. "Memberships in inventory-service: Closing the SMD Parity Gap"
+3. "Flexible Hardware Identification: An Early Look at the RFD"
+4. "fabrica Observability: Prometheus Metrics in Progress"

--- a/content/news/weekly/2026-04-20.md
+++ b/content/news/weekly/2026-04-20.md
@@ -1,0 +1,62 @@
+---
+title: "OpenCHAMI Weekly Digest: Apr 13–Apr 20, 2026"
+date: "2026-04-20T09:00:00"
+slug: "weekly-digest-2026-04-20"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+Two big themes: a six-PR `inventory-service` cleanup sprint from shunr-hpe, and the OpenCHAMI Developer Summit @ UCL 2026 agenda getting its final shape. Plus a `tokensmith` RFC 8693 refactor and the closure of a long-standing `boot-service` legacy-API issue.
+
+## Highlights
+
+- **inventory-service cleanup sprint:** shunr-hpe lands six PRs in a tight batch — [PR #14](https://github.com/OpenCHAMI/inventory-service/pull/14) (project rename to `inventory-service`), [#15](https://github.com/OpenCHAMI/inventory-service/pull/15) (remove unneeded `go.mod` replaces), [#16](https://github.com/OpenCHAMI/inventory-service/pull/16) (EthernetInterface description handling), [#17](https://github.com/OpenCHAMI/inventory-service/pull/17) (Makefile + test targets), [#18](https://github.com/OpenCHAMI/inventory-service/pull/18) (package rename `controllers` → `providers`), and the earlier-week [`smd` #87](https://github.com/OpenCHAMI/smd/pull/87) (functional-test fix). Solid hygiene work.
+- **tokensmith RFC 8693 support:** [`tokensmith` PR #22](https://github.com/OpenCHAMI/tokensmith/pull/22) from alexlovelltroy refactors the TokenService to support [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) for opaque token management. Lands in [tokensmith v0.4.0](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.4.0); [v0.4.1](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.4.1) follows the next day with a quick patch.
+- **boot-service legacy API issue closed:** [`boot-service` #1](https://github.com/OpenCHAMI/boot-service/issues/1) — the long-running BSS-compatibility ask on `/boot/v1/bootparameters` — closes this week. Connects to the [boot-service v0.1.1](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.1) release.
+- **coresmd per-rule netmask action:** [`coresmd` PR #59](https://github.com/OpenCHAMI/coresmd/pull/59) from synackd adds a per-rule netmask action with docs updates, closing the netmask/cidr inference ask from [`coresmd` #58](https://github.com/OpenCHAMI/coresmd/issues/58).
+- **UCL 2026 Summit prep continues:** Multiple `openchami.org` PRs polish the Summit: [Day 1 reorganisation](https://github.com/OpenCHAMI/openchami.org/pull/93), [Day 2 AI workshop schedule fix](https://github.com/OpenCHAMI/openchami.org/pull/92), [venue and session-room changes](https://github.com/OpenCHAMI/openchami.org/pull/91), and [tutorial update](https://github.com/OpenCHAMI/openchami.org/pull/94) from new contributor darkmatterdawn. Plus [Install Slurm doc updated to use cloud-init](https://github.com/OpenCHAMI/openchami.org/pull/82) from lunamorrow.
+- **Deployment recipes bump to v0.1.2:** [`deployment-recipes` PR #145](https://github.com/OpenCHAMI/deployment-recipes/pull/145) from mithileshreddy04 updates the OpenCHAMI release reference to v0.1.2.
+
+## New & Notable PRs
+
+- [RFC 8693 opaque tokens (tokensmith #22)](https://github.com/OpenCHAMI/tokensmith/pull/22) by alexlovelltroy
+- [Per-rule netmask action (coresmd #59)](https://github.com/OpenCHAMI/coresmd/pull/59) by synackd
+- [Project rename + cleanup (inventory-service #14)](https://github.com/OpenCHAMI/inventory-service/pull/14) by shunr-hpe
+- [Test targets + Makefile (inventory-service #17)](https://github.com/OpenCHAMI/inventory-service/pull/17) by shunr-hpe
+- [UCL Day 1 reorganisation (openchami.org #93)](https://github.com/OpenCHAMI/openchami.org/pull/93) by green-br
+- [Cloud-init in Install Slurm docs (openchami.org #82)](https://github.com/OpenCHAMI/openchami.org/pull/82) by lunamorrow
+
+## Issues to Watch
+
+No fresh blockers in this window — the active issues from prior weeks (magellan BMC config, structured logging, hardware identification RFD) continue to gather discussion.
+
+## Releases
+
+- [tokensmith v0.4.1](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.4.1)
+- [tokensmith v0.4.0](https://github.com/OpenCHAMI/tokensmith/releases/tag/v0.4.0) — RFC 8693 opaque tokens
+- [boot-service v0.1.1](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.1)
+
+## Contributor Thanks
+
+- **shunr-hpe** — six inventory-service PRs in one week of cleanup and DX work.
+- **alexlovelltroy** — tokensmith RFC 8693 refactor.
+- **synackd** — coresmd netmask action plus ongoing review across many repos.
+- **green-br, aescoubas, darkmatterdawn** — UCL 2026 Summit content polishing.
+- **lunamorrow** — Slurm-on-cloud-init docs update.
+
+---
+
+## What’s next?
+
+- Ship UCL 2026 Summit final content before the event.
+- Continue inventory-service growth on the cleaner foundation.
+- Land [`fabrica` #39 Prometheus metrics](https://github.com/OpenCHAMI/fabrica/pull/39) and start using them in services.
+
+## Proposed Blog Titles
+
+1. "RFC 8693 in Practice: Opaque Token Management in tokensmith v0.4"
+2. "inventory-service: A Week in Hygiene"
+3. "Get Ready for OpenCHAMI Developer Summit @ UCL 2026"
+4. "Slurm on OpenCHAMI: The cloud-init Path"

--- a/content/news/weekly/2026-04-27.md
+++ b/content/news/weekly/2026-04-27.md
@@ -1,0 +1,66 @@
+---
+title: "OpenCHAMI Weekly Digest: Apr 20–Apr 27, 2026"
+date: "2026-04-27T09:00:00"
+slug: "weekly-digest-2026-04-27"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A strong release week with five tags shipping, the first ever `gpg-signing-manager` PR, and an OpenAPI discovery RFD on the table.
+
+## Highlights
+
+- **gpg-signing-manager opens up:** [`gpg-signing-manager` PR #1](https://github.com/OpenCHAMI/gpg-signing-manager/pull/1) — the first PR on this repo — from synackd switches to separate repo keys instead of subkeys. A meaningful change to the signing trust model used by the release pipeline.
+- **boot-service expansion:** [`boot-service` PR #11](https://github.com/OpenCHAMI/boot-service/pull/11) from synackd adds openapi API routes, and [PR #7](https://github.com/OpenCHAMI/boot-service/pull/7) from alexlovelltroy upgrades the underlying fabrica. [`boot-service` v0.1.2](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.2) ships at end of week, accompanied by [ochami's bump to boot-service v0.1.1](https://github.com/OpenCHAMI/ochami/pull/77) earlier in the week.
+- **OpenAPI Discovery RFD opened:** [`roadmap` #124](https://github.com/OpenCHAMI/roadmap/issues/124) from alexlovelltroy — a standardized OpenAPI discovery endpoint across OpenCHAMI services. Pairs naturally with the [`ochami` #78](https://github.com/OpenCHAMI/ochami/issues/78) ask for choosing API versions of fabrica services.
+- **aarch64 release issues close:** [`release` #42](https://github.com/OpenCHAMI/release/issues/42) (local-ca aarch64) and [`release` #43](https://github.com/OpenCHAMI/release/issues/43) (broader aarch64) — both from middelkoopt — closed this week. The aarch64 arc that started in March is winding down.
+- **Cloud-init networking inject closes:** [`boot-service` #6](https://github.com/OpenCHAMI/boot-service/issues/6) from travisbcotton — inject cloud-init networking from boot-service — closed this week, along with [`boot-service` PR #2](https://github.com/OpenCHAMI/boot-service/pull/2) (ethernet interface unmarshal fix from davidallendj).
+- **Release pipeline tightens:** [`release` PR #49](https://github.com/OpenCHAMI/release/pull/49) streamlines the ephemeral GPG key generation and signing process; [PR #48](https://github.com/OpenCHAMI/release/pull/48) bumps `bss`, `smd`, and `local-ca` versions; [PR #40](https://github.com/OpenCHAMI/release/pull/40) from erl-hpe adds `:ro,Z` to coresmd-coredns container volume specs (selinux-friendly).
+- **fabrica v0.4.1 + reconciler guardrails:** [`fabrica` v0.4.1](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.1) ships. New PR [#46](https://github.com/OpenCHAMI/fabrica/pull/46) from bmcdonald3 throws when reconcilers are configured without events and lowers default worker count to 1 — guardrails against subtle misconfigurations.
+- **Container instructions for tutorial:** [`openchami.org` PR #95](https://github.com/OpenCHAMI/openchami.org/pull/95) from green-br adds optional container instructions.
+
+## New & Notable PRs
+
+- [Separate repo keys instead of subkeys (gpg-signing-manager #1)](https://github.com/OpenCHAMI/gpg-signing-manager/pull/1) by synackd
+- [openapi API routes (boot-service #11)](https://github.com/OpenCHAMI/boot-service/pull/11) by synackd
+- [Upgrade fabrica (boot-service #7)](https://github.com/OpenCHAMI/boot-service/pull/7) by alexlovelltroy
+- [Streamline ephemeral GPG signing (release #49)](https://github.com/OpenCHAMI/release/pull/49) by alexlovelltroy
+- [Reconciler/event guardrails (fabrica #46)](https://github.com/OpenCHAMI/fabrica/pull/46) by bmcdonald3
+
+## Issues to Watch
+
+- [Standardized OpenAPI Discovery Endpoint (roadmap #124)](https://github.com/OpenCHAMI/roadmap/issues/124) — new RFD; foundational for client tooling.
+- [Choose API version for fabrica services (ochami #78)](https://github.com/OpenCHAMI/ochami/issues/78) — companion to the discovery RFD.
+
+## Releases
+
+- [boot-service v0.1.2](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.2)
+- [fabrica v0.4.1](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.1)
+- [release v0.1.4](https://github.com/OpenCHAMI/release/releases/tag/v0.1.4)
+- [release v0.1.3](https://github.com/OpenCHAMI/release/releases/tag/v0.1.3)
+- [ochami v0.7.2](https://github.com/OpenCHAMI/ochami/releases/tag/v0.7.2)
+
+## Contributor Thanks
+
+- **synackd** — gpg-signing-manager first commit + boot-service openapi routes + release pipeline GPG cleanup.
+- **alexlovelltroy** — boot-service fabrica upgrade, OpenAPI discovery RFD, release-pipeline GPG streamlining.
+- **bmcdonald3** — fabrica reconciler guardrails.
+- **middelkoopt** — drove the aarch64 release issues to closure.
+- **mithileshreddy04, erl-hpe, green-br, darkmatterdawn** — deployment-recipes, release, and tutorial polish.
+
+---
+
+## What’s next?
+
+- Land [`fabrica` #46](https://github.com/OpenCHAMI/fabrica/pull/46) reconciler guardrails and continue using fabrica through more services.
+- Move discussion forward on [`roadmap` #124](https://github.com/OpenCHAMI/roadmap/issues/124) OpenAPI discovery endpoint.
+- Prepare for the UCL 2026 Summit — most of the content scaffolding is now in.
+
+## Proposed Blog Titles
+
+1. "Separate Repo Keys: A Cleaner Signing Trust Model in OpenCHAMI"
+2. "Standardized OpenAPI Discovery: An Early Look at the RFD"
+3. "Five Releases in a Week: OpenCHAMI's Release Cadence"
+4. "Cloud-Init Networking from boot-service: How It Came Together"

--- a/content/news/weekly/2026-05-04.md
+++ b/content/news/weekly/2026-05-04.md
@@ -1,0 +1,63 @@
+---
+title: "OpenCHAMI Weekly Digest: Apr 27–May 04, 2026"
+date: "2026-05-04T09:00:00"
+slug: "weekly-digest-2026-05-04"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+Five releases this week, the first tagged `ipxe-binaries` release with Broadcom firmware support, and continued UCL 2026 Summit final-prep. Plus the first Dependabot PRs landing in `cloud-init` — the cross-org dep-update story is gaining ground.
+
+## Highlights
+
+- **ipxe-binaries v0.1.0 — first tagged release:** [`ipxe-binaries` v0.1.0](https://github.com/OpenCHAMI/ipxe-binaries/releases/tag/v0.1.0) ships, building on long-standing [PR #1](https://github.com/OpenCHAMI/ipxe-binaries/pull/1) (attestations, from late 2024) plus this week's [PR #3](https://github.com/OpenCHAMI/ipxe-binaries/pull/3) from abhishek-sa1 (ipxe v2.0.0 for latest Broadcom firmware NIC support).
+- **inventory-service gains a Hardware resource type:** [`inventory-service` PR #20](https://github.com/OpenCHAMI/inventory-service/pull/20) from shunr-hpe adds the Hardware resource — a key model for the [Flexible Hardware Identification RFD](https://github.com/OpenCHAMI/roadmap/issues/122).
+- **fabrica v0.4.2 + docs cleanup:** [`fabrica` v0.4.2](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.2) ships, plus seantronsen's [`fabrica` PR #43](https://github.com/OpenCHAMI/fabrica/pull/43) lands the documentation cleanup that closed earlier complaints about outdated tutorials.
+- **release v0.1.5 + coresmd v0.4.3 bump:** [`release` v0.1.5](https://github.com/OpenCHAMI/release/releases/tag/v0.1.5) ships, and [`release` PR #51](https://github.com/OpenCHAMI/release/pull/51) bumps coresmd v0.4.0 → v0.4.3 in the release definition.
+- **kube-deploy gets CI:** [`kube-deploy` PR #9](https://github.com/OpenCHAMI/kube-deploy/pull/9) from rainest proposes adding CI; [PR #8](https://github.com/OpenCHAMI/kube-deploy/pull/8) fixes a "not-quite numbers" YAML quoting issue.
+- **Dependabot active in cloud-init:** Three new dep bumps opened in [`cloud-init`](https://github.com/OpenCHAMI/cloud-init/pulls) — [#105 go-jose v4](https://github.com/OpenCHAMI/cloud-init/pull/105), [#106 golang.org/x/crypto](https://github.com/OpenCHAMI/cloud-init/pull/106), [#107 mapstructure v2](https://github.com/OpenCHAMI/cloud-init/pull/107). Dependabot is doing its job; reviewers needed.
+- **UCL 2026 Summit final-prep:** [Final presenters update](https://github.com/OpenCHAMI/openchami.org/pull/99) by dominicfriend, and the [UCL page expanded to multiple pages](https://github.com/OpenCHAMI/openchami.org/pull/98) for clearer attendee navigation.
+
+## New & Notable PRs
+
+- [ipxe v2.0.0 for Broadcom firmware NICs (ipxe-binaries #3)](https://github.com/OpenCHAMI/ipxe-binaries/pull/3) by abhishek-sa1
+- [Hardware resource type (inventory-service #20)](https://github.com/OpenCHAMI/inventory-service/pull/20) by shunr-hpe
+- [fabrica documentation cleanup (fabrica #43)](https://github.com/OpenCHAMI/fabrica/pull/43) by seantronsen
+- [Add CI (kube-deploy #9)](https://github.com/OpenCHAMI/kube-deploy/pull/9) by rainest
+- [Expanded UCL pages (openchami.org #98)](https://github.com/OpenCHAMI/openchami.org/pull/98) by alexlovelltroy
+
+## Issues to Watch
+
+No fresh blockers this week; activity is on the PR side.
+
+## Releases
+
+- [release v0.1.5](https://github.com/OpenCHAMI/release/releases/tag/v0.1.5)
+- [fabrica v0.4.2](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.2)
+- [coresmd v0.4.3](https://github.com/OpenCHAMI/coresmd/releases/tag/v0.4.3) (via [release PR #51](https://github.com/OpenCHAMI/release/pull/51))
+- [ipxe-binaries v0.1.0](https://github.com/OpenCHAMI/ipxe-binaries/releases/tag/v0.1.0) — first tagged release
+- [boot-service v0.1.2](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.2) (from last week, surfaced now)
+
+## Contributor Thanks
+
+- **abhishek-sa1** — Broadcom firmware NIC support in ipxe-binaries.
+- **shunr-hpe** — Hardware resource type in inventory-service.
+- **rainest** — kube-deploy CI proposal + YAML quoting fix.
+- **dominicfriend, alexlovelltroy, green-br** — UCL 2026 Summit final-prep content.
+- **seantronsen** — fabrica documentation cleanup.
+
+---
+
+## What’s next?
+
+- Review and merge the three open `cloud-init` Dependabot PRs.
+- Move `kube-deploy` CI [PR #9](https://github.com/OpenCHAMI/kube-deploy/pull/9) toward landing.
+- Final UCL 2026 Summit content review before the event.
+
+## Proposed Blog Titles
+
+1. "ipxe-binaries v0.1.0: Modern NICs, Modern Boot"
+2. "Hardware as a Resource: How inventory-service Models the Stack"
+3. "CI for kube-deploy: Catching Regressions Earlier"

--- a/content/news/weekly/2026-05-11.md
+++ b/content/news/weekly/2026-05-11.md
@@ -1,0 +1,77 @@
+---
+title: "OpenCHAMI Weekly Digest: May 04–May 11, 2026"
+date: "2026-05-11T09:00:00"
+slug: "weekly-digest-2026-05-11"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A *big* week. Seven releases including **inventory-service v0.1.0** (the first tag), a built-in **MCP server** in fabrica, a Single System Image RFD on the table, and group-membership-from-SMD in boot-service.
+
+## Highlights
+
+- **inventory-service v0.1.0 — the first release:** [`inventory-service` v0.1.0](https://github.com/OpenCHAMI/inventory-service/releases/tag/v0.1.0) tags. Months of work from shunr-hpe culminates: [`inventory-service` PR #21](https://github.com/OpenCHAMI/inventory-service/pull/21) adds the GitHub release workflow and goreleaser build, and [PR #22](https://github.com/OpenCHAMI/inventory-service/pull/22) refactors and expands the SMD-compare tests.
+- **fabrica gets a built-in MCP server:** [`fabrica` PR #47](https://github.com/OpenCHAMI/fabrica/pull/47) from alexlovelltroy lands a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server. Significant new direction — fabrica-based services can be discovered and interacted with by MCP-aware tools (Claude Desktop, agents, etc.) out of the box.
+- **fabrica releases this week:** [`fabrica` v0.4.4](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.4) and [v0.4.3](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.3) ship. The release brings: [PR #49](https://github.com/OpenCHAMI/fabrica/pull/49) (keep fabrica from regenerating files when only the header changed), [PR #44](https://github.com/OpenCHAMI/fabrica/pull/44) (purely local generation bugfix), [PR #45](https://github.com/OpenCHAMI/fabrica/pull/45) (init path fix for agentic tools), [PR #21](https://github.com/OpenCHAMI/fabrica/pull/21) (SPDX line moves + authorship), [PR #50](https://github.com/OpenCHAMI/fabrica/pull/50) (version doc bump), and [PR #52](https://github.com/OpenCHAMI/fabrica/pull/52) (enhanced version display, still open).
+- **boot-service ships v0.1.3 and v0.1.4:** [`boot-service` v0.1.4](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.4) and [v0.1.3](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.3) ship with [PR #12](https://github.com/OpenCHAMI/boot-service/pull/12) (group membership from SMD by travisbcotton) and [PR #10](https://github.com/OpenCHAMI/boot-service/pull/10) (boot profile clarification by alexlovelltroy).
+- **fru-tracker v0.2.2 with build automation:** [`fru-tracker` v0.2.2](https://github.com/OpenCHAMI/fru-tracker/releases/tag/v0.2.2) ships [PR #18](https://github.com/OpenCHAMI/fru-tracker/pull/18) from alexlovelltroy: Makefile + GitHub workflow updates for proper build automation.
+- **Single System Image RFD:** [`roadmap` #125](https://github.com/OpenCHAMI/roadmap/issues/125) from jordiblasco proposes Single System Image for cluster provisioning — a strategic direction worth deep discussion.
+- **OpenCHAMI installation/deployment tool proposed:** [`release` #53](https://github.com/OpenCHAMI/release/issues/53) from erl-hpe — a turnkey deployment tool based on the tutorials. Connects to the existing [`deployment-recipes`](https://github.com/OpenCHAMI/deployment-recipes) work.
+- **cloud-init mem-store boot-time init:** [`cloud-init` PR #103](https://github.com/OpenCHAMI/cloud-init/pull/103) from rainest adds basic memory-store initialization at boot — improving cold-start behavior.
+- **Inventory Service blog post in progress:** [`openchami.org` PR #97](https://github.com/OpenCHAMI/openchami.org/pull/97) from shunr-hpe drafts a blog post for inventory-service, timed for the v0.1.0 release.
+
+## New & Notable PRs
+
+- [Built-in MCP server (fabrica #47)](https://github.com/OpenCHAMI/fabrica/pull/47) by alexlovelltroy
+- [Group membership from SMD (boot-service #12)](https://github.com/OpenCHAMI/boot-service/pull/12) by travisbcotton
+- [GitHub release workflow + goreleaser (inventory-service #21)](https://github.com/OpenCHAMI/inventory-service/pull/21) by shunr-hpe
+- [Refactored SMD-compare tests (inventory-service #22)](https://github.com/OpenCHAMI/inventory-service/pull/22) by shunr-hpe
+- [Skip regenerating on header-only change (fabrica #49)](https://github.com/OpenCHAMI/fabrica/pull/49) by alexlovelltroy
+- [Build automation for fru-tracker (fru-tracker #18)](https://github.com/OpenCHAMI/fru-tracker/pull/18) by alexlovelltroy
+- [mem-store boot-time init (cloud-init #103)](https://github.com/OpenCHAMI/cloud-init/pull/103) by rainest
+
+## Issues to Watch
+
+- [Introduce Single System Image for cluster provisioning (roadmap #125)](https://github.com/OpenCHAMI/roadmap/issues/125) — RFD; strategic.
+- [OpenCHAMI Installation/Deployment Tool (release #53)](https://github.com/OpenCHAMI/release/issues/53) — turnkey deployment ask.
+- [No cloud config from `/meta-data` (metadata-service #9)](https://github.com/OpenCHAMI/metadata-service/issues/9) — looks like a meaningful bug to triage.
+- [Work with a nodes directory (ex-bootstrap #5)](https://github.com/OpenCHAMI/ex-bootstrap/issues/5) — extends the cabinet-discovery work.
+
+## Releases
+
+- [inventory-service v0.1.0](https://github.com/OpenCHAMI/inventory-service/releases/tag/v0.1.0) — **first release**
+- [fabrica v0.4.4](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.4)
+- [fabrica v0.4.3](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.3)
+- [boot-service v0.1.4](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.4)
+- [boot-service v0.1.3](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.3)
+- [fru-tracker v0.2.2](https://github.com/OpenCHAMI/fru-tracker/releases/tag/v0.2.2)
+- [release v0.1.5](https://github.com/OpenCHAMI/release/releases/tag/v0.1.5)
+
+## Contributor Thanks
+
+- **shunr-hpe** — inventory-service v0.1.0 first release; sustained momentum from months of work.
+- **alexlovelltroy** — fabrica MCP server, fabrica build polish, fru-tracker automation. Big week.
+- **travisbcotton** — group-membership-from-SMD in boot-service.
+- **rainest** — cloud-init mem-store boot-time init.
+- **bmcdonald3** — fabrica init path fix for agentic tools.
+- **jordiblasco** — Single System Image RFD.
+- **erl-hpe** — deployment tool ask.
+
+---
+
+## What’s next?
+
+- Open RFD discussion on [Single System Image (roadmap #125)](https://github.com/OpenCHAMI/roadmap/issues/125).
+- Triage [metadata-service #9 cloud-config bug](https://github.com/OpenCHAMI/metadata-service/issues/9).
+- Land [`fabrica` #52 enhanced version display](https://github.com/OpenCHAMI/fabrica/pull/52).
+- Scope the [OpenCHAMI deployment tool ask (release #53)](https://github.com/OpenCHAMI/release/issues/53) against existing tutorials and `deployment-recipes`.
+
+## Proposed Blog Titles
+
+1. "inventory-service v0.1.0: A First Look"
+2. "fabrica Speaks MCP: AI Agents Meet OpenCHAMI Services"
+3. "Single System Image: A New Direction for Cluster Provisioning?"
+4. "Group Membership From SMD: How boot-service Knows Who You Are"
+5. "A Turnkey OpenCHAMI Installer: Early Thinking"

--- a/content/news/weekly/2026-05-18.md
+++ b/content/news/weekly/2026-05-18.md
@@ -1,0 +1,74 @@
+---
+title: "OpenCHAMI Weekly Digest: May 11–May 18, 2026"
+date: "2026-05-18T09:00:00"
+slug: "weekly-digest-2026-05-18"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A landmark week — **metadata-service v0.1.0** ships as a first release alongside **smd v2.20.0** with optional tokensmith authentication, plus an `ochami boot service status` command and a fabrica health-endpoint addition.
+
+## Highlights
+
+- **metadata-service v0.1.0 — first release:** [`metadata-service` v0.1.0](https://github.com/OpenCHAMI/metadata-service/releases/tag/v0.1.0) ships. The release incorporates [PR #6](https://github.com/OpenCHAMI/metadata-service/pull/6) (Profile resource), [PR #7](https://github.com/OpenCHAMI/metadata-service/pull/7) (fabrica 0.3.0 + Profile/WireGuardPeer reconcilers), [PR #8](https://github.com/OpenCHAMI/metadata-service/pull/8) (fabrica upgrade), and forward-looking work in [PR #13](https://github.com/OpenCHAMI/metadata-service/pull/13) (WireGuard peer reconciliation).
+- **smd v2.20.0 with TokenSmith authentication:** [`smd` v2.20.0](https://github.com/OpenCHAMI/smd/releases/tag/v2.20.0) ships [PR #86](https://github.com/OpenCHAMI/smd/pull/86) — optional TokenSmith authentication features in SMD. A foundational integration. [`smd` v2.20.3](https://github.com/OpenCHAMI/smd/releases/tag/v2.20.3) followed with patches the same day.
+- **smd CI/CD overhauled:** [`smd` PR #88](https://github.com/OpenCHAMI/smd/pull/88) (alexlovelltroy — CI/CD + GoReleaser improvements), [#89](https://github.com/OpenCHAMI/smd/pull/89) (PR-build env from travisbcotton), and [#90](https://github.com/OpenCHAMI/smd/pull/90) (remove Windows from smd-loader goos list). The smd release pipeline gets meaningfully better.
+- **fabrica v0.4.5 with health endpoint:** [`fabrica` v0.4.5](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.5) ships [PR #53](https://github.com/OpenCHAMI/fabrica/pull/53) (health check endpoint + tests). The missing-API-endpoints bug in [`fabrica` #51](https://github.com/OpenCHAMI/fabrica/issues/51) was also closed.
+- **ochami v0.7.3 brings boot-service status:** [`ochami` v0.7.3](https://github.com/OpenCHAMI/ochami/releases/tag/v0.7.3) ships [PR #79](https://github.com/OpenCHAMI/ochami/pull/79) — new `ochami boot service status` command. Also closes the [`ochami` #68 SMD interface query parameter bug](https://github.com/OpenCHAMI/ochami/issues/68) via [PR #83 from new contributor Wafffle77](https://github.com/OpenCHAMI/ochami/pull/83).
+- **boot-service v0.1.5 with health/version endpoints:** [`boot-service` v0.1.5](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.5) ships [PR #13](https://github.com/OpenCHAMI/boot-service/pull/13) (fabrica 0.4.4 upgrade), and closes [`boot-service` #5 (health/version endpoints)](https://github.com/OpenCHAMI/boot-service/issues/5) and [#8 (broken docker-build)](https://github.com/OpenCHAMI/boot-service/issues/8). [PR #14](https://github.com/OpenCHAMI/boot-service/pull/14) adds a `CONTAINER_PROG` Makefile variable for runtime flexibility.
+- **WireGuard reconciliation lands in metadata-service:** [`metadata-service` PR #13](https://github.com/OpenCHAMI/metadata-service/pull/13) implements WireGuard peer reconciliation and tests — open, with companion issues [#10 (reconciliation runtime)](https://github.com/OpenCHAMI/metadata-service/issues/10) and [#11 (TokenSmith-backed dynamic SMD authentication)](https://github.com/OpenCHAMI/metadata-service/issues/11) opened the same day.
+- **Magellan input-format work:** [`magellan` PR #130](https://github.com/OpenCHAMI/magellan/pull/130) — `collect` accepting input in specified format — open, addressing [`magellan` #128 from February](https://github.com/OpenCHAMI/magellan/issues/128).
+- **Community governance items close:** [`community` #43 (Fabrica replacements for legacy services agenda)](https://github.com/OpenCHAMI/community/issues/43) closed, and [PR #44](https://github.com/OpenCHAMI/community/pull/44) adds a "TSC Agenda Item" label to the agenda template.
+
+## New & Notable PRs
+
+- [TokenSmith authentication for SMD (smd #86)](https://github.com/OpenCHAMI/smd/pull/86) by alexlovelltroy
+- [WireGuard peer reconciliation (metadata-service #13)](https://github.com/OpenCHAMI/metadata-service/pull/13) by alexlovelltroy
+- [Health check endpoint (fabrica #53)](https://github.com/OpenCHAMI/fabrica/pull/53) by alexlovelltroy
+- [`ochami boot service status` (ochami #79)](https://github.com/OpenCHAMI/ochami/pull/79) by synackd
+- [SMD-loader goos cleanup (smd #90)](https://github.com/OpenCHAMI/smd/pull/90) by travisbcotton
+- [SMD query parameter assignment (ochami #83)](https://github.com/OpenCHAMI/ochami/pull/83) by Wafffle77
+
+## Issues to Watch
+
+- [TokenSmith-backed dynamic SMD authentication for metadata-service (metadata-service #11)](https://github.com/OpenCHAMI/metadata-service/issues/11) — natural extension of the smd v2.20.0 work.
+- [Reconciliation runtime + WireGuard lifecycle (metadata-service #10)](https://github.com/OpenCHAMI/metadata-service/issues/10) — the reconciler framework for the next stage of metadata-service.
+- [Submitting Agenda Topics in GitHub (community #42)](https://github.com/OpenCHAMI/community/issues/42) — still open from slandath's earlier work.
+- [Profile-based control for metadata and #cloud-config (metadata-service #5)](https://github.com/OpenCHAMI/metadata-service/issues/5) — long-running profile-based control work still active.
+
+## Releases
+
+- [metadata-service v0.1.0](https://github.com/OpenCHAMI/metadata-service/releases/tag/v0.1.0) — **first release**
+- [smd v2.20.0](https://github.com/OpenCHAMI/smd/releases/tag/v2.20.0) — TokenSmith authentication
+- [smd v2.20.3](https://github.com/OpenCHAMI/smd/releases/tag/v2.20.3)
+- [fabrica v0.4.5](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.5) — health check endpoint
+- [boot-service v0.1.5](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.5)
+- [ochami v0.7.3](https://github.com/OpenCHAMI/ochami/releases/tag/v0.7.3) — `boot service status`
+
+## Contributor Thanks
+
+- **alexlovelltroy** — smd TokenSmith auth, fabrica health endpoint, metadata-service reconciler work. Big week.
+- **synackd** — `ochami boot service status` command + boot-service Makefile cleanup + TSC label work.
+- **travisbcotton** — smd CI/CD fixes.
+- **shunr-hpe** — sustained inventory-service work + blog post drafting.
+- **davidallendj** — magellan input-format PR.
+- **Wafffle77** — new contributor; landed an ochami fix on the SMD query parameter assignment.
+- **slandath** — TSC agenda template polish.
+
+---
+
+## What’s next?
+
+- Wire [`metadata-service` TokenSmith dynamic auth (#11)](https://github.com/OpenCHAMI/metadata-service/issues/11) against the new smd v2.20 TokenSmith features.
+- Land [`metadata-service` PR #13 WireGuard reconciliation](https://github.com/OpenCHAMI/metadata-service/pull/13).
+- Continue building out fabrica-based services on the v0.4.5 health-endpoint pattern.
+
+## Proposed Blog Titles
+
+1. "metadata-service v0.1.0: A First Release"
+2. "TokenSmith Meets SMD: A Look at smd v2.20.0"
+3. "`ochami boot service status`: A Practical Look at the New Command"
+4. "WireGuard Reconciliation in metadata-service"
+5. "How OpenCHAMI Services Get Health Endpoints — fabrica v0.4.5"

--- a/content/news/weekly/2026-05-25.md
+++ b/content/news/weekly/2026-05-25.md
@@ -1,0 +1,82 @@
+---
+title: "OpenCHAMI Weekly Digest: May 18–May 25, 2026"
+date: "2026-05-25T09:00:00"
+slug: "weekly-digest-2026-05-25"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+A productive week with `fru-tracker` reaching v0.2.4, `coresmd` v0.6.2 landing multi-subnet DHCP, and a new HPC-VM RFD opening up. Also some real SMD bugs surface around `RedfishEndpoint` parsing.
+
+## Highlights
+
+- **fru-tracker v0.2.4 + reconciliation enhancements:** [`fru-tracker` v0.2.4](https://github.com/OpenCHAMI/fru-tracker/releases/tag/v0.2.4) and [v0.2.3](https://github.com/OpenCHAMI/fru-tracker/releases/tag/v0.2.3) ship. Highlights: [PR #19](https://github.com/OpenCHAMI/fru-tracker/pull/19) (reconciliation logic for devices without serial numbers, from bmcdonald3) and [PR #20](https://github.com/OpenCHAMI/fru-tracker/pull/20) (Docker runtime + SQLite pathing fixes). Plus [PR #21](https://github.com/OpenCHAMI/fru-tracker/pull/21) updating build automation.
+- **coresmd v0.6.2 with multi-subnet DHCP:** [`coresmd` v0.6.2](https://github.com/OpenCHAMI/coresmd/releases/tag/v0.6.2) ships [PR #61 from new contributor sujit-jadhav](https://github.com/OpenCHAMI/coresmd/pull/61) — multi-subnet DHCP support for multi-RAC deployments.
+- **HPC-VM RFD opened:** [`roadmap` #127](https://github.com/OpenCHAMI/roadmap/issues/127) from alexlovelltroy — OpenCHAMI-managed templated HPC virtual machines. Connects to the [Single System Image RFD](https://github.com/OpenCHAMI/roadmap/issues/125) from last week.
+- **OpenHPC PR integration report:** [`release` #54](https://github.com/OpenCHAMI/release/issues/54) from adrianreber documents running OpenCHAMI in OpenHPC pull requests. Cross-community signal worth noting.
+- **SMD V2 RedfishEndpoint parsing bug surfaced:** [`smd` #91](https://github.com/OpenCHAMI/smd/issues/91) from alexlovelltroy — V2 parser inserts NodeBMC Components but never creates the matching ComponentEndpointManager records. davidallendj's [PR #92](https://github.com/OpenCHAMI/smd/pull/92) addresses it by adding BMC Manager `ComponentEndpoint`s and `ManagerInfo` to `parseRedfishEndpointDataV2`.
+- **power-control bugs and ARM disable:** [`power-control` #66](https://github.com/OpenCHAMI/power-control/issues/66) — updateComponentMap never refreshing existing hwStateMap entries — closed. cjh1 lands [PR #67](https://github.com/OpenCHAMI/power-control/pull/67) (allow SMD metadata updates), and rainest opens [PR #68](https://github.com/OpenCHAMI/power-control/pull/68) to temporarily disable ARM builds pending a fix.
+- **inventory-service ARM + schema validation:** shunr-hpe lands [PR #24](https://github.com/OpenCHAMI/inventory-service/pull/24) (ARM in goreleaser build) and opens [PR #23](https://github.com/OpenCHAMI/inventory-service/pull/23) for JSON-schema-based validation.
+- **metadata-service SMD integration with dynamic tokens:** [`metadata-service` PR #14](https://github.com/OpenCHAMI/metadata-service/pull/14) from alexlovelltroy adds an SMD integration service with caching and dynamic token support — implementing the TokenSmith-dynamic-auth feature opened last week.
+- **ochami CI improvements:** synackd lands [PR #85](https://github.com/OpenCHAMI/ochami/pull/85) (auto-generated PR build containers) and [PR #87](https://github.com/OpenCHAMI/ochami/pull/87) (cleanup.yaml logic hotfix).
+- **Long-standing custom-fields question closed:** [`smd` #84](https://github.com/OpenCHAMI/smd/issues/84) from Katakam-Rakesh — extra_config nodes.yaml storage + cloud-init exposure — closed.
+
+## New & Notable PRs
+
+- [Multi-subnet DHCP for multi-RAC (coresmd #61)](https://github.com/OpenCHAMI/coresmd/pull/61) by sujit-jadhav
+- [BMC Manager ComponentEndpoints in V2 parser (smd #92)](https://github.com/OpenCHAMI/smd/pull/92) by davidallendj
+- [SMD integration with caching + dynamic tokens (metadata-service #14)](https://github.com/OpenCHAMI/metadata-service/pull/14) by alexlovelltroy
+- [Allow SMD metadata updates (power-control #67)](https://github.com/OpenCHAMI/power-control/pull/67) by cjh1
+- [Device reconciliation without serial numbers (fru-tracker #19)](https://github.com/OpenCHAMI/fru-tracker/pull/19) by bmcdonald3
+- [ARM in goreleaser (inventory-service #24)](https://github.com/OpenCHAMI/inventory-service/pull/24) by shunr-hpe
+- [Auto PR build containers (ochami #85)](https://github.com/OpenCHAMI/ochami/pull/85) by synackd
+- [install-openchami in openchami-release (release #52)](https://github.com/OpenCHAMI/release/pull/52) by erl-hpe
+
+## Issues to Watch
+
+- [Templated HPC VMs (roadmap #127)](https://github.com/OpenCHAMI/roadmap/issues/127) — new RFD; strategic.
+- [V2 RedfishEndpoint parser missing CompendpointManager records (smd #91)](https://github.com/OpenCHAMI/smd/issues/91) — real bug affecting BMC management.
+- [OpenCHAMI in OpenHPC PR integration (release #54)](https://github.com/OpenCHAMI/release/issues/54) — cross-community signal.
+- [Add metadata-service commands to ochami (ochami #81)](https://github.com/OpenCHAMI/ochami/issues/81) — CLI side of metadata-service v0.1.0.
+- [JWT support in boot-service client (boot-service #4)](https://github.com/OpenCHAMI/boot-service/issues/4) — sibling of the SMD TokenSmith integration.
+- [Post-image-CD cleanup (power-control #58)](https://github.com/OpenCHAMI/power-control/issues/58) — long-running.
+
+## Releases
+
+- [coresmd v0.6.2](https://github.com/OpenCHAMI/coresmd/releases/tag/v0.6.2) — multi-subnet DHCP
+- [fru-tracker v0.2.4](https://github.com/OpenCHAMI/fru-tracker/releases/tag/v0.2.4)
+- [fru-tracker v0.2.3](https://github.com/OpenCHAMI/fru-tracker/releases/tag/v0.2.3)
+- [fru-tracker pr-21](https://github.com/OpenCHAMI/fru-tracker/releases/tag/pr-21)
+- [fru-tracker pr-20](https://github.com/OpenCHAMI/fru-tracker/releases/tag/pr-20)
+- [fru-tracker pr-19](https://github.com/OpenCHAMI/fru-tracker/releases/tag/pr-19)
+
+## Contributor Thanks
+
+- **alexlovelltroy** — metadata-service SMD integration, build-automation polish across multiple repos, RFD work.
+- **bmcdonald3** — fru-tracker reconciliation logic + Docker fixes.
+- **shunr-hpe** — inventory-service ARM + JSON schema validation.
+- **davidallendj** — smd RedfishEndpoint parser fix.
+- **cjh1** — power-control SMD metadata updates.
+- **synackd** — ochami CI improvements.
+- **sujit-jadhav** — new contributor with multi-subnet DHCP support in coresmd.
+- **adrianreber** — OpenHPC PR integration report.
+- **erl-hpe** — install-openchami direction.
+
+---
+
+## What’s next?
+
+- Triage and close [`smd` #91 RedfishEndpoint parsing bug](https://github.com/OpenCHAMI/smd/issues/91) — davidallendj's PR is the candidate fix.
+- Pick up [`ochami` #81 metadata-service commands](https://github.com/OpenCHAMI/ochami/issues/81) — closes the CLI surface gap.
+- Open RFD discussion on [templated HPC VMs (roadmap #127)](https://github.com/OpenCHAMI/roadmap/issues/127).
+- Land [`metadata-service` SMD integration (#14)](https://github.com/OpenCHAMI/metadata-service/pull/14) and validate against the smd v2.20 TokenSmith path.
+
+## Proposed Blog Titles
+
+1. "Multi-Subnet DHCP in coresmd: A Multi-RAC Story"
+2. "Templated HPC VMs in OpenCHAMI: An Early Look at the RFD"
+3. "BMC ComponentEndpoints: Closing the SMD V2 Parser Gap"
+4. "Dynamic Tokens at Runtime: How metadata-service Talks to SMD"
+5. "Running OpenCHAMI in OpenHPC PRs: A Cross-Project Integration"

--- a/content/news/weekly/archive/_index.md
+++ b/content/news/weekly/archive/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Weekly Updates Archive"
+description = "Every OpenCHAMI weekly engineering and ops update, most recent first"
+layout = "weekly-archive"
+date = 2025-11-10T00:00:00Z
+draft = false
++++
+
+Every weekly digest published since the series began. Most recent first.

--- a/layouts/news/weekly-aggregate.html
+++ b/layouts/news/weekly-aggregate.html
@@ -6,28 +6,62 @@
       {{ with .Content }}<div class="lead">{{ . }}</div>{{ end }}
     </header>
 
-    {{/* Collect pages from content/news/weekly (this branch) */}}
+    {{/* Collect pages from content/news/weekly (this branch only — excludes any
+         pages under sub-sections like /news/weekly/archive/) */}}
     {{ $weekly := where (where site.RegularPages "File.Dir" "in" "/news/weekly/") "Section" "news" }}
     {{ $sorted := sort $weekly "Date" "desc" }}
 
     {{ if not (gt (len $weekly) 0) }}
       <p>No weekly updates found yet.</p>
     {{ else }}
-      <div class="list-group list-group-flush">
-        {{ range $sorted }}
-          <article class="list-group-item px-0">
-            <h2 class="h5 mb-1"><a class="stretched-link text-decoration-none" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
-            <div class="post-meta small text-muted mb-2">
-              <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
-            </div>
-            {{ with .Params.summary }}
-              <p class="mb-0">{{ . }}</p>
-            {{ else }}
-              {{ with .Summary }}<p class="mb-0">{{ . }}</p>{{ end }}
-            {{ end }}
-          </article>
-        {{ end }}
+      {{ $latest := index $sorted 0 }}
+      {{ $recent := after 1 $sorted | first 5 }}
+
+      {{/* Latest update — rendered in full */}}
+      <article class="latest-update mb-5">
+        <h2 class="mb-2">
+          <a href="{{ $latest.RelPermalink }}" class="text-decoration-none">{{ $latest.Title }}</a>
+        </h2>
+        <div class="post-meta small text-muted mb-3">
+          <time datetime="{{ $latest.Date.Format "2006-01-02" }}">{{ $latest.Date.Format "Jan 2, 2006" }}</time>
+        </div>
+        <div class="content">
+          {{ $latest.Content }}
+        </div>
+      </article>
+
+      {{/* Recent updates list */}}
+      {{ if gt (len $recent) 0 }}
+      <section class="recent-updates mt-5 pt-4 border-top">
+        <h2 class="h4 mb-3">Recent updates</h2>
+        <div class="list-group list-group-flush">
+          {{ range $recent }}
+            <article class="list-group-item px-0">
+              <h3 class="h5 mb-1"><a class="stretched-link text-decoration-none" href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+              <div class="post-meta small text-muted mb-2">
+                <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
+              </div>
+              {{ with .Params.summary }}
+                <p class="mb-0">{{ . }}</p>
+              {{ else }}
+                {{/* Skip the leading "OpenCHAMI Weekly Digest" H1 (3 words), then take ~40 words. */}}
+                {{ $excerpt := delimit (first 40 (after 3 .PlainWords)) " " }}
+                {{ with $excerpt }}<p class="mb-0 text-muted">{{ . }}…</p>{{ end }}
+              {{ end }}
+            </article>
+          {{ end }}
+        </div>
+      </section>
+      {{ end }}
+
+      {{/* Archive link — only when there are older digests beyond the latest + recent */}}
+      {{ if gt (len $sorted) 6 }}
+      <div class="archive-link mt-4 text-center">
+        <a href="/news/weekly/archive/" class="btn btn-outline-primary">
+          Browse the full archive ({{ len $sorted }} updates) &rarr;
+        </a>
       </div>
+      {{ end }}
     {{ end }}
   </div>
 </div>

--- a/layouts/news/weekly-archive.html
+++ b/layouts/news/weekly-archive.html
@@ -1,0 +1,69 @@
+{{ define "main" }}
+<div class="row justify-content-center">
+  <div class="col-md-12 col-lg-9">
+    <header class="mb-4">
+      <nav class="small text-muted mb-2">
+        <a href="/news/weekly/" class="text-decoration-none">&larr; Back to Weekly Updates</a>
+      </nav>
+      <h1>{{ .Title }}</h1>
+      {{ with .Content }}<div class="lead">{{ . }}</div>{{ end }}
+    </header>
+
+    {{/* All weekly digests, regardless of age. Source dir mirrors the landing layout. */}}
+    {{ $weekly := where (where site.RegularPages "File.Dir" "in" "/news/weekly/") "Section" "news" }}
+    {{ $sorted := sort $weekly "Date" "desc" }}
+
+    {{ if not (gt (len $weekly) 0) }}
+      <p>No weekly updates found yet.</p>
+    {{ else }}
+      <p class="text-muted small mb-4">{{ len $sorted }} updates, most recent first.</p>
+      <div class="list-group list-group-flush">
+        {{ range $sorted }}
+          <article class="list-group-item px-0">
+            <h2 class="h5 mb-1"><a class="stretched-link text-decoration-none" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+            <div class="post-meta small text-muted mb-2">
+              <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
+            </div>
+            {{ with .Params.summary }}
+              <p class="mb-0">{{ . }}</p>
+            {{ else }}
+              {{/* Skip the leading "OpenCHAMI Weekly Digest" H1 (3 words), then take ~40 words. */}}
+              {{ $excerpt := delimit (first 40 (after 3 .PlainWords)) " " }}
+              {{ with $excerpt }}<p class="mb-0 text-muted">{{ . }}…</p>{{ end }}
+            {{ end }}
+          </article>
+        {{ end }}
+      </div>
+    {{ end }}
+  </div>
+</div>
+
+{{/* Inject JSON-LD for the archive */}}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Weekly Updates Archive",
+  "description": "Browse every OpenCHAMI weekly engineering and ops update",
+  "url": "{{ .Permalink }}",
+  "hasPart": [
+    {{ range $sorted }}
+    {
+      "@type": "BlogPosting",
+      "headline": "{{ .Title }}",
+      "url": "{{ .Permalink }}",
+      "datePublished": "{{ .Date.Format "2006-01-02" }}",
+      "author": [
+        {{ range .Params.contributors }}
+        {
+          "@type": "Person",
+          "name": "{{ . }}"
+        }{{ if not (eq . (index $.Params.contributors (sub (len $.Params.contributors) 1))) }},{{ end }}
+        {{ end }}
+      ]
+    }{{ if not (eq . (index $sorted (sub (len $sorted) 1))) }},{{ end }}
+    {{ end }}
+  ]
+}
+</script>
+{{ end }}


### PR DESCRIPTION
- Created weekly digest entries for April 27, May 4, May 11, May 18, and May 25, 2026, detailing significant updates, releases, and contributor acknowledgments.
- Introduced an archive page for all weekly updates, allowing users to browse past digests.
- Enhanced the weekly aggregate layout to display the latest update prominently and list recent updates with excerpts.
- Implemented JSON-LD structured data for the archive page to improve SEO and content discoverability.


---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
