### PR TITLE
OpenCHAMI Weekly Digest: Jun 15–Jun 22, 2026

### DIFF
--- a/content/news/weekly/2026-06-22.md
+++ b/content/news/weekly/2026-06-22.md
@@ -1,0 +1,64 @@
+---
+title: "OpenCHAMI Weekly Digest: Jun 15–Jun 22, 2026"
+date: "2026-06-22T09:00:00"
+slug: "weekly-digest-2026-06-22"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+## Highlights
+- **Ochami v0.8.1 Released**: Latest updates with bug fixes and new metadata-service commands, improving boot image handling and system control. [Release details](https://github.com/OpenCHAMI/ochami/releases/tag/v0.8.1)
+- **Simplified Installation and RPM Packaging for Legendary-Funicular**: New features including a curl-based installer and RPM packages aim to make setup easier and standardized. Explore improvements [here](https://github.com/OpenCHAMI/legendary-funicular/issues/6) and [here](https://github.com/OpenCHAMI/legendary-funicular/issues/5).
+- **Standardizing Logs and Schemas**: Legendary-Funicular is improving structured data consistency by standardizing schema values like `level`. [See issue](https://github.com/OpenCHAMI/legendary-funicular/issues/4)
+- **Firmware-Updater Usability Boosts**: Multiple merged PRs refined firmware discovery using ORAS metadata, removed hardcoded paths, and enhanced command usability. [Read more](https://github.com/OpenCHAMI/firmware-updater/pull/5)
+- **Automatic OpenCHAMI Startup**: Release repo added optional systemd auto-start to improve out-of-the-box operation. [PR #59](https://github.com/OpenCHAMI/release/issues/59)
+- **Metadata-Service Improvements**: Added YAML tagging, container target improvements, and a migration command to enhance data management and deployment. Check out [v0.1.2 release](https://github.com/OpenCHAMI/metadata-service/releases/tag/v0.1.2)
+- **Robust Dependency Updates Across Repos**: Dependabot automated bumps across tokensmith, inventory-service, metadata-service, and cloud-init ensure current, secure libraries with chi v5.2.4.
+- **Magellan Exploration Features**: New PRs bring experimental serve commands and GoFish upgrades as part of ongoing roadmap exploration efforts. [Explore PRs](https://github.com/OpenCHAMI/magellan/pulls)
+- **Community Collaboration on Governance**: A proposed roadmap issue suggests introducing org-wide CODEOWNERS, SECURITY protocols, and Dependabot alerts to boost security and maintenance. [Issue #131](https://github.com/OpenCHAMI/roadmap/issues/131)
+- **Installer and CLI Enhancements**: Integration-sandbox working on adding the ochami CLI; ochami adding kernel parameter flag support for boot images to improve customization. [Integration issue #4](https://github.com/OpenCHAMI/integration-sandbox/issues/4), [Ochami PR #103](https://github.com/OpenCHAMI/ochami/pull/103)
+
+## New & Notable PRs
+- [Firmware-Updater: Command fixes and README improvements](https://github.com/OpenCHAMI/firmware-updater/pulls?q=author:bmcdonald3)
+- [Power-Control: Bug fix and docs update](https://github.com/OpenCHAMI/power-control/pulls?q=author:cjh1)
+- [Various Dependabot bumps to chi v5.2.4](https://github.com/OpenCHAMI/inventory-service/pulls?q=is:pr+author:dependabot%5Bbot%5D)
+- [Ochami: Support for array patch operations in boot resources](https://github.com/OpenCHAMI/ochami/pull/100)
+- [Magellan: Roadmap exploration features](https://github.com/OpenCHAMI/magellan/pulls?q=author:alexlovelltroy)
+
+## Issues to Watch
+- [Open bug in Legendary-Funicular: `scope=all` fails when no files exist](https://github.com/OpenCHAMI/legendary-funicular/issues/9) may impact some users running comprehensive scopes.
+- [OpenChami CLI integration in the Integration Sandbox](https://github.com/OpenCHAMI/integration-sandbox/issues/4) will ease user workflows once completed.
+- [Roadmap Issue #131: Org-wide governance proposal](https://github.com/OpenCHAMI/roadmap/issues/131) – community feedback welcomed.
+
+## Releases
+- [Ochami v0.8.1](https://github.com/OpenCHAMI/ochami/releases/tag/v0.8.1)
+- [Release v0.1.6](https://github.com/OpenCHAMI/release/releases/tag/v0.1.6)
+- [Fabrica v0.4.8](https://github.com/OpenCHAMI/fabrica/releases/tag/v0.4.8)
+- [Boot-Service v0.1.7](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.1.7)
+- [Metadata-Service v0.1.2](https://github.com/OpenCHAMI/metadata-service/releases/tag/v0.1.2)
+
+## Contributor Thanks
+- @seantronsen for multiple impactful features and bug fixes in Legendary-Funicular.
+- @synackd for enhancements across Fabrica, Metadata-Service, Boot-Service, and Ochami.
+- @bmcdonald3 for refining Firmware-Updater usability and documentation.
+- @alexlovelltroy for driving important roadmap discussions and contributions in Magellan.
+- @darkmatterdawn for improving Release automation and systemd integration.
+- Dependabot bot for keeping core dependencies fresh and secure.
+
+---
+
+## What’s next?
+- Finalize and merge the ochami CLI integration for improved developer experience.
+- Close out remaining Legendary-Funicular issues focusing on installer and schema improvements.
+- Engage the community on org-wide governance proposals to enhance security and collaboration.
+- Continue expanding Magellan features for enhanced management and exploration capabilities.
+- Publish detailed blog posts that highlight recent installer improvements and usage tips.
+
+## Proposed Blog Titles
+1. "Streamlining OpenCHAMI Installation: New RPM Packages and Curl Installer"
+2. "How Ochami v0.8.1 Enhances Boot Image Flexibility and Metadata Management"
+3. "Behind the Scenes: Strengthening OpenCHAMI with Dependency Updates and Governance"
+4. "Exploring Magellan: New Features for OpenCHAMI Roadmap Innovation"
+5. "Getting Started Fast: Auto-Starting OpenCHAMI with Systemd Integration"


### PR DESCRIPTION
This PR adds the weekly digest post generated on 2026-06-22.

- Post path: `content/news/weekly/2026-06-22.md`
- Slug: `weekly-digest-2026-06-22`

Please review copy and publish.
