### PR TITLE
fix: spotfix unnecessary parameter expansion in tutorial kickstart.conf he…

### DIFF
--- a/content/docs/tutorial.md
+++ b/content/docs/tutorial.md
@@ -295,7 +295,7 @@ mkdir serve/
 Then, create `kickstart.conf` within that directory:
 
 ```bash
-cat > serve/kickstart.conf << EOF
+cat > serve/kickstart.conf << 'EOF'
 #version=RHEL9
 # Use text install
 text


### PR DESCRIPTION
…redoc

## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

There's a small logic error in the currently published `openchami.org` tutorial in which a few unintended parameter expansions break the proposed `kickstart.conf` file.

Since no other shell nor parameter expansions occur in this particular HEREDOC, I simply added quotes to the EOF marker to disable the behavior. 

Without this, kickstart fails since the url vars like `$basearch` eagerly expand at the time the file is written, resulting in an empty `<content>//<content>` pattern in the final URL.

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [x] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
