### PR TITLE
OpenCHAMI Weekly Digest: Jul 21–Jul 28, 2026

### DIFF
--- a/content/news/weekly/2026-07-28.md
+++ b/content/news/weekly/2026-07-28.md
@@ -1,0 +1,60 @@
+---
+title: "OpenCHAMI Weekly Digest: Jul 21–Jul 28, 2026"
+date: "2026-07-28T09:00:00"
+slug: "weekly-digest-2026-07-28"
+tags: ["weekly", "updates", "openchami"]
+draft: false
+---
+
+# OpenCHAMI Weekly Digest
+
+## Highlights
+- **Improved API Spec Customization**: Fabrica users requested better control over OpenAPI specs, including configurable server URLs and custom routes. ([#86](https://github.com/OpenCHAMI/fabrica/issues/86), [#87](https://github.com/OpenCHAMI/fabrica/issues/87))
+- **Adopting New UID Format**: Fabrica is considering switching to TypeID/UUIDv7 as the default for resource unique IDs, improving consistency and future-proofing. ([#85](https://github.com/OpenCHAMI/fabrica/issues/85))
+- **Expanded Hardware Data Collection**: Magellan users flagged missing per-DIMM memory, CPU details, and GPU/PCIe device data from Redfish sources, enhancing hardware monitoring capabilities. ([#143](https://github.com/OpenCHAMI/magellan/issues/143))
+- **Bug Fixes in Key Services**: Ochami and Metadata Service have several outstanding bug reports aiming to fix format type use, logging precedence, env variable names, and command information for more reliable and user-friendly operations. ([#125](https://github.com/OpenCHAMI/ochami/issues/125), [#124](https://github.com/OpenCHAMI/ochami/issues/124), [#41](https://github.com/OpenCHAMI/metadata-service/issues/41))
+- **Dependency Management Automation Continuing**: Renovate bot opened multiple dependency dashboard issues and dependency update PRs across repos maintaining secure and up-to-date libraries. ([Community](https://github.com/OpenCHAMI/community/pull/48), [Ochami](https://github.com/OpenCHAMI/ochami/pull/128))
+- **Power-Control Service Enhancements**: Improved CI stability by implementing service health checks and avoiding duplicate workflow runs to speed up integration. ([#130](https://github.com/OpenCHAMI/power-control/pull/130))
+- **Recent Stable Releases**: Boot-Service v0.3.0 and Metadata-Service v0.2.0 introduce important functionality updates. Multiple micro-releases for Fru-Tracker and Image-Thrillhouse enhance stability and features. ([Boot-Service v0.3.0](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.3.0))
+- **Migration towards Fabrica-generated Services**: Tokensmith is advancing a move to Fabrica-generated services, streamlining service architecture. ([#46](https://github.com/OpenCHAMI/tokensmith/issues/46))
+
+## New & Notable PRs
+- [Fix weekly digest payload size for GPT-4.1-mini](https://github.com/OpenCHAMI/community/pull/47) – Ensures digest generation stays within token limits.
+- [Update various dependency versions across multiple repos](https://github.com/OpenCHAMI/ochami/pull/128), including security patches and action updates.
+- [Replace fixed CI waits with health checks in Power-Control](https://github.com/OpenCHAMI/power-control/pull/130) – Boosts CI reliability and speed.
+- [Configure Renovate Bot in Community repo](https://github.com/OpenCHAMI/community/pull/48) – Automates dependency management workflow.
+
+## Issues to Watch
+- Configurability gaps in Fabrica's OpenAPI spec generation limiting custom user integrations. ([#86](https://github.com/OpenCHAMI/fabrica/issues/86), [#87](https://github.com/OpenCHAMI/fabrica/issues/87))
+- Missing detailed hardware data in Magellan affecting monitoring completeness. ([#143](https://github.com/OpenCHAMI/magellan/issues/143))
+- Logging merge issues and environment variable naming consistency in Ochami and Metadata Service impacting usability and debugging. ([#124](https://github.com/OpenCHAMI/ochami/issues/124), [#40](https://github.com/OpenCHAMI/metadata-service/issues/40))
+- Conversion progress of Tokensmith to Fabrica-generated services, important for ecosystem standardization. ([#46](https://github.com/OpenCHAMI/tokensmith/issues/46))
+
+## Releases
+- [Boot-Service v0.3.0](https://github.com/OpenCHAMI/boot-service/releases/tag/v0.3.0) – Updated service features and stability improvements.
+- [Metadata-Service v0.2.0](https://github.com/OpenCHAMI/metadata-service/releases/tag/v0.2.0) – New capabilities and bug fixes.
+- Multiple incremental releases for Fru-Tracker ([e.g., pr-31](https://github.com/OpenCHAMI/fru-tracker/releases/tag/pr-31)) and Image-Thrillhouse ([v0.0.20](https://github.com/OpenCHAMI/image-thrillhouse/releases/tag/v0.0.20)).
+
+## Contributor Thanks
+Thanks to all contributors this week, especially:
+- synackd for addressing multiple bug reports and service improvements.
+- renovate[bot] and dependabot[bot] for proactive dependency updates.
+- seantronsen and alexlovelltroy for driving Fabrica feature enhancements.
+- cjh1 for improving testing and CI in Power-Control.
+- The broader community for continuous engagement and support.
+
+---
+
+## What’s Next?
+- Finalizing the configuration flexibility in Fabrica’s OpenAPI spec generation to support diverse deployment setups.
+- Enhancing Magellan's hardware data coverage to unlock richer insights.
+- Migrating more services like Tokensmith to the Fabrica-generated architecture for uniformity.
+- Continuing dependency updates and automated tooling adoption across repositories.
+- Improving logging and environment variable conventions for consistent developer experience.
+
+## Proposed Blog Titles
+- "Unlocking Flexible APIs: Customizing OpenAPI Specs in Fabrica"
+- "Magellan Hardware Insights: Toward Complete Redfish Data Collection"
+- "From Tokensmith to Fabrica: Modernizing Service Architectures at OpenCHAMI"
+- "Behind the Scenes: How Automated Dependency Management Keeps OpenCHAMI Secure"
+- "Boot-Service v0.3.0 & Metadata-Service v0.2.0: What’s New and Improved"


### PR DESCRIPTION
This PR adds the weekly digest post generated on 2026-07-28.

- Post path: `content/news/weekly/2026-07-28.md`
- Slug: `weekly-digest-2026-07-28`

Please review copy and publish.
